### PR TITLE
[codex] Data-drive Homebrew installers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run start.sh through Docker sandbox
-        run: |
-          {
-            printf '1\n'
-            printf '2\n'
-            for _ in {1..32}; do
-              printf 'n\n'
-            done
-          } | ./start.sh
+        run: bash ./ci/docker_start_smoke.sh vim-modern

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,8 @@ Changes should preserve the following goals.
 16. **Discoverable logs and backups**
     Install state should be inspectable after the fact through
     `~/.mac_setup/log` and `~/.mac_setup/backups`.
+
+17. **Complete pattern adoption**
+    When a new framework pattern is introduced, existing code should be migrated
+    to that pattern before the work is considered complete. Avoid leaving mixed
+    old/new approaches unless there is an explicit compatibility reason.

--- a/ci/checks.sh
+++ b/ci/checks.sh
@@ -35,5 +35,8 @@ echo "Checking focused package configuration behavior..."
 echo "Checking idempotent file edit helpers..."
 ./ci/test_file_edits.sh
 
+echo "Checking installer helpers..."
+./ci/test_installers.sh
+
 echo "Checking section registry and prompt wrapper..."
 ./ci/test_section_registry.sh

--- a/ci/docker_start_smoke.sh
+++ b/ci/docker_start_smoke.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+profile="${1:-vim-modern}"
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$repo_root"
+
+case "$profile" in
+  vim-old)
+    profile_choice=1
+    ;;
+  vim-modern)
+    profile_choice=2
+    ;;
+  *)
+    echo "Usage: ci/docker_start_smoke.sh [vim-old|vim-modern]" >&2
+    exit 2
+    ;;
+esac
+
+no_prompts() {
+  for _ in {1..32}; do
+    printf 'n\n'
+  done
+}
+
+{
+  printf '1\n'
+  printf '%s\n' "$profile_choice"
+  no_prompts
+} | ./start.sh

--- a/ci/test_installers.sh
+++ b/ci/test_installers.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$repo_root"
+
+tmp_home="$(mktemp -d)"
+tmp_bin="$(mktemp -d)"
+tmp_state="$(mktemp -d)"
+brew_log="$tmp_state/brew.log"
+cleanup() {
+  rm -rf "$tmp_home" "$tmp_bin" "$tmp_state"
+}
+trap cleanup EXIT
+
+cat > "$tmp_bin/brew" <<'BREW'
+#!/bin/bash
+
+set -euo pipefail
+
+case "$1" in
+  list|ls)
+    if [ "${2:-}" = "--formula" ] && [ "${3:-}" = "--versions" ]; then
+      test -f "$BREW_STATE/formula-$4"
+      exit "$?"
+    fi
+    exit 2
+    ;;
+  tap)
+    echo "tap $2" >> "$BREW_LOG"
+    ;;
+  install)
+    echo "install $2" >> "$BREW_LOG"
+    touch "$BREW_STATE/formula-$2"
+    cat > "$TMP_BIN/probe-command" <<'COMMAND'
+#!/bin/sh
+exit 0
+COMMAND
+    chmod +x "$TMP_BIN/probe-command"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+BREW
+chmod +x "$tmp_bin/brew"
+
+echo "Checking Homebrew package helper install and rerun behavior..."
+HOME="$tmp_home" \
+PATH="$tmp_bin:$PATH" \
+TERM="${TERM:-xterm}" \
+BREW_LOG="$brew_log" \
+BREW_STATE="$tmp_state" \
+TMP_BIN="$tmp_bin" \
+bash -c '
+  source ./lib/macsetup/constants.sh
+  source ./lib/macsetup/helperFunctions.sh
+  set -euo pipefail
+
+  configureProbe() {
+    echo "configure probe" >> "$BREW_LOG"
+  }
+
+  installHomebrewPackagesFromList "Probe Package|probe-formula|probe-command|configureProbe|example/tap"
+  installHomebrewPackagesFromList "Probe Package|probe-formula|probe-command|configureProbe|example/tap"
+
+  test "$(grep -cFx "tap example/tap" "$BREW_LOG")" -eq 1
+  test "$(grep -cFx "install probe-formula" "$BREW_LOG")" -eq 1
+  test "$(grep -cFx "configure probe" "$BREW_LOG")" -eq 2
+  test "${#FAILURES_ARRAY[@]}" -eq 0
+'

--- a/lib/macsetup/installers.sh
+++ b/lib/macsetup/installers.sh
@@ -4,42 +4,96 @@
 # Installer Functions #
 #######################
 
-installPackage() {
-  info "Installing Package: $1"
-  if cmdExists "$1"; then
-    info "$1 is already installed"
+brewPackageInstalled() {
+  brew list --formula --versions "$1" > /dev/null 2>&1
+}
+
+installHomebrewPackage() {
+  local display_name="$1"
+  local formula="$2"
+  local assertion_command="$3"
+  local configure_function="${4:-}"
+  local tap="${5:-}"
+
+  info "Installing Package: $display_name"
+
+  if brewPackageInstalled "$formula"; then
+    info "$display_name is already installed"
   else
-    $2
-    if [ -n "$3" ]; then
-      $3
+    if [ -n "$tap" ] && ! brew tap "$tap"; then
+      fail "Failed to tap Homebrew repository: $tap"
+      return 1
     fi
+
+    if ! brew install "$formula"; then
+      fail "Failed to install Homebrew package: $display_name"
+      return 1
+    fi
+  fi
+
+  if [ -n "$configure_function" ]; then
+    "$configure_function"
+  fi
+
+  if [ -n "$assertion_command" ]; then
+    assertPackageInstallation "$assertion_command" "$display_name"
   fi
 }
 
+installHomebrewPackagesFromList() {
+  local package_entry=""
+  local display_name=""
+  local formula=""
+  local assertion_command=""
+  local configure_function=""
+  local tap=""
+
+  for package_entry in "$@"; do
+    IFS='|' read -r display_name formula assertion_command configure_function tap <<< "$package_entry"
+    installHomebrewPackage "$display_name" "$formula" "$assertion_command" "$configure_function" "$tap"
+  done
+}
+
+caskInstallAppsFromList() {
+  local app_entry=""
+  local app_name=""
+  local cask_name=""
+  local configure_function=""
+
+  for app_entry in "$@"; do
+    IFS='|' read -r app_name cask_name configure_function <<< "$app_entry"
+    caskInstallAppPrompt "$app_name" "$cask_name" "$configure_function"
+  done
+}
+
 caskInstallAppPrompt() {
-  promptYesNo "Install application $1?"
+  local app_name="$1"
+  local cask_name="$2"
+  local configure_function="${3:-}"
+
+  promptYesNo "Install application $app_name?"
 
   if [[ $REPLY =~ ^[Yy]$ ]]; then
-    info "Installing Application: $1"
-    if brew ls --cask --versions "$2" > /dev/null 2>&1; then
-      warn "$1 is already installed. Prompting overwrite..."
-      promptYesNo "Do you want to $RED OVERWRITE $RESET_COLOR application $1?"
+    info "Installing Application: $app_name"
+    if brew ls --cask --versions "$cask_name" > /dev/null 2>&1; then
+      warn "$app_name is already installed. Prompting overwrite..."
+      promptYesNo "Do you want to $RED OVERWRITE $RESET_COLOR application $app_name?"
       if [[ $REPLY =~ ^[Yy]$ ]]; then
-        rm -rf "/Applications/$1"
-        brew reinstall --cask "$2"
-        if [ -n "$3" ]; then
-          $3
+        rm -rf "/Applications/$app_name"
+        brew reinstall --cask "$cask_name"
+        if [ -n "$configure_function" ]; then
+          "$configure_function"
         fi
       else
         info "Skipping overwrite..."
       fi
     else
-      brew install --cask "$2"
-      if [ -n "$3" ]; then
-        $3
+      brew install --cask "$cask_name"
+      if [ -n "$configure_function" ]; then
+        "$configure_function"
       fi
     fi
-    assertAppInstallation "$1"
+    assertAppInstallation "$app_name"
   else
     info "Skipping Installation..."
   fi

--- a/sections/install_applications.sh
+++ b/sections/install_applications.sh
@@ -9,42 +9,25 @@ installApplications() {
   if isMacOs; then
     # Can only install brew apps if brew is installed
     if cmdExists brew; then
-      # Install Caffeine
-      caskInstallAppPrompt "Caffeine.app" "caffeine"
-      # Install Sip Color Picker
-      caskInstallAppPrompt "Sip.app" "sip"
-      # Install Flux
-      caskInstallAppPrompt "Flux.app" "flux"
-      # Install Postman
-      caskInstallAppPrompt "Postman.app" "postman"
-      # Install Spotify
-      caskInstallAppPrompt "Spotify.app" "spotify"
-      # Install Beekeeper Studio (Postgres GUI)
-      caskInstallAppPrompt "Beekeeper Studio.app" "beekeeper-studio"
-      # Install Slack
-      caskInstallAppPrompt "Slack.app" "slack"
-      # Install VirtualBox
-      caskInstallAppPrompt "VirtualBox.app" "virtualbox"
-      # Install Firefox
-      caskInstallAppPrompt "Firefox.app" "firefox"
-      # Install Gimp
-      caskInstallAppPrompt "Gimp.app" "gimp"
-      # Install Docker
-      caskInstallAppPrompt "Docker.app" "docker" configureDocker
-      # Preserve white space by changing the Internal Field Separator
-      IFS='%'
-      # Install and configure Chrome
-      caskInstallAppPrompt "Google Chrome.app" "google-chrome"
-      # Reset the Internal Field Separator
-      unset IFS
+      local applications=(
+        "Caffeine.app|caffeine|"
+        "Sip.app|sip|"
+        "Flux.app|flux|"
+        "Postman.app|postman|"
+        "Spotify.app|spotify|"
+        "Beekeeper Studio.app|beekeeper-studio|"
+        "Slack.app|slack|"
+        "VirtualBox.app|virtualbox|"
+        "Firefox.app|firefox|"
+        "Gimp.app|gimp|"
+        "Docker.app|docker|configureDocker"
+        "Google Chrome.app|google-chrome|"
+        "Rectangle.app|rectangle|configureRectangle"
+        "Visual Studio Code.app|visual-studio-code|configureVSCode"
+        "iTerm.app|iterm2|configureITerm"
+      )
 
-      # Install applications that need configuring
-      # Install Rectangle
-      caskInstallAppPrompt "Rectangle.app" "rectangle" configureRectangle
-      # Install Visual Studio Code
-      caskInstallAppPrompt "Visual Studio Code.app" "visual-studio-code" configureVSCode
-      # Install and configure iTerm2
-      caskInstallAppPrompt "iTerm.app" "iterm2" configureITerm
+      caskInstallAppsFromList "${applications[@]}"
 
       # Cleanup downloads
       info "Cleaning up application .zip and .dmg files"

--- a/sections/install_homebrew_packages.sh
+++ b/sections/install_homebrew_packages.sh
@@ -8,72 +8,31 @@ function runSection {
 installHomebrewPackages() {
   # Can only install brew packages if brew is installed
   if cmdExists brew; then
-    # Install openssl
-    # TODO: When openssl exists, configureOpenSSL is not ran, but when openssl
-    # is installed/configured with homebrew -- Postgres via asdf fails to install
-    installPackage openssl "brew install openssl" configureOpenSSL
-    assertPackageInstallation openssl "openssl"
-    # Install icu4c
-    installPackage icu4c "brew install icu4c" configureICU4C
-    assertPackageInstallation icuinfo "icu4c"
-    # Install fzf
-    installPackage fzf "brew install fzf"
-    assertPackageInstallation fzf "fzf"
-    # Install gcc
-    installPackage gcc "brew install gcc"
-    assertPackageInstallation gcc "gcc"
-    # Install lolcat
-    installPackage lolcat "brew install lolcat"
-    assertPackageInstallation lolcat "lolcat"
-    # Install wget
-    installPackage wget "brew install wget"
-    assertPackageInstallation wget "wget"
-    # Install curl
-    installPackage curl "brew install curl"
-    assertPackageInstallation curl "curl"
-    # Install tree
-    installPackage tree "brew install tree"
-    assertPackageInstallation tree "tree"
-    # Install gpg
-    installPackage gpg "brew install gpg"
-    assertPackageInstallation gpg "gpg"
-    # Install ack
-    installPackage ack "brew install ack"
-    assertPackageInstallation ack "ack"
-    # Install viu
-    installPackage viu "brew install viu"
-    assertPackageInstallation viu "viu"
-    # Install yarn
-    installPackage yarn "brew install yarn"
-    assertPackageInstallation yarn "yarn"
-    # Install delta
-    installPackage delta "brew install git-delta"
-    assertPackageInstallation delta "delta (Better 'diff' Command)"
-    # Install ytop
-    installPackage ytop `brew tap cjbassi/ytop ; brew install ytop`
-    assertPackageInstallation ytop "ytop (Better 'top' Command)"
-    # Install htop
-    installPackage htop "brew install htop"
-    assertPackageInstallation htop "htop (Alternative 'top' Command)"
-    # Install bat
-    installPackage bat "brew install bat"
-    assertPackageInstallation bat "bat (Better 'cat' Command)"
-    configureBat
-    # Install procs
-    installPackage procs "brew install procs"
-    assertPackageInstallation procs "procs (Better 'ps' Command)"
-    # Install lsd
-    installPackage lsd "brew install lsd"
-    assertPackageInstallation lsd "lsd (Better 'ls' Command)"
-    # Install ripgrep
-    installPackage rg "brew install ripgrep"
-    assertPackageInstallation rg "Ripgrep"
-    # Install jnv
-    installPackage jnv "brew install jnv"
-    assertPackageInstallation jnv "jnv (Interactive jq JSON Viewer)"
-    # Install code-minimap
-    installPackage code-minimap "brew install code-minimap"
-    assertPackageInstallation code-minimap "code-minimap (Text-based minimaps)"
+    local packages=(
+      "openssl|openssl|openssl|configureOpenSSL|"
+      "icu4c|icu4c|icuinfo|configureICU4C|"
+      "fzf|fzf|fzf||"
+      "gcc|gcc|gcc||"
+      "lolcat|lolcat|lolcat||"
+      "wget|wget|wget||"
+      "curl|curl|curl||"
+      "tree|tree|tree||"
+      "gpg|gpg|gpg||"
+      "ack|ack|ack||"
+      "viu|viu|viu||"
+      "yarn|yarn|yarn||"
+      "delta (Better 'diff' Command)|git-delta|delta||"
+      "ytop (Better 'top' Command)|ytop|ytop||cjbassi/ytop"
+      "htop (Alternative 'top' Command)|htop|htop||"
+      "bat (Better 'cat' Command)|bat|bat|configureBat|"
+      "procs (Better 'ps' Command)|procs|procs||"
+      "lsd (Better 'ls' Command)|lsd|lsd||"
+      "Ripgrep|ripgrep|rg||"
+      "jnv (Interactive jq JSON Viewer)|jnv|jnv||"
+      "code-minimap (Text-based minimaps)|code-minimap|code-minimap||"
+    )
+
+    installHomebrewPackagesFromList "${packages[@]}"
   else
     fail "Failed to install brew packages. Homebrew is not installed."
   fi

--- a/sections/install_zsh.sh
+++ b/sections/install_zsh.sh
@@ -8,9 +8,7 @@ function runSection {
 installZsh() {
   # Can only install brew packages if brew is installed
   if cmdExists brew; then
-    # Install zsh
-    installPackage zsh "brew install zsh"
-    assertPackageInstallation zsh "zsh"
+    installHomebrewPackage "zsh" "zsh" "zsh"
   else
     fail "Failed to install zsh. Homebrew is required to install."
   fi


### PR DESCRIPTION
## Summary
- Replace repeated Homebrew package and cask install calls with list-driven helpers.
- Remove the old string-command installPackage path and make zsh use the Homebrew helper.
- Add installer helper tests, a reusable Docker start smoke script, and the complete-pattern-adoption tenet.

## Validation
- bash ./ci/checks.sh
- bash ./ci/docker_start_smoke.sh vim-modern
- git diff --check