### PR TITLE
[codex] Fix Ghostty shell startup errors

### DIFF
--- a/ci/checks.sh
+++ b/ci/checks.sh
@@ -21,6 +21,9 @@ printf '3\n' | ./start.sh
 echo "Checking UI prompt behavior..."
 bash ./ci/test_ui.sh
 
+echo "Checking shell startup helpers..."
+bash ./ci/test_shell_startup.sh
+
 echo "Checking install.sh skipped-section path with isolated HOME..."
 tmp_home="$(mktemp -d)"
 cleanup() {

--- a/ci/test_shell_startup.sh
+++ b/ci/test_shell_startup.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$repo_root"
+
+tmp_home="$(mktemp -d)"
+tmp_bin="$(mktemp -d)"
+stderr_file="$(mktemp)"
+cleanup() {
+  rm -rf "$tmp_home" "$tmp_bin" "$stderr_file"
+}
+trap cleanup EXIT
+
+cat > "$tmp_bin/lolcat" <<'LOLCAT'
+#!/bin/sh
+cat >/dev/null
+LOLCAT
+chmod +x "$tmp_bin/lolcat"
+
+echo "Checking startup helpers with unknown Ghostty terminfo..."
+HOME="$tmp_home" \
+PATH="$tmp_bin:$PATH" \
+TERM=xterm-ghostty \
+COLUMNS= \
+bash -c '
+  source ./lib/macsetup/constants.sh
+  source ./config/dotfiles/mac/utility_aliases.sh
+  source ./config/dotfiles/mac/splash_screens.sh
+
+  test "$(splashTerminalColumns)" = "80"
+  wolf >/dev/null
+  charizard >/dev/null
+' 2>"$stderr_file"
+
+if [ -s "$stderr_file" ]; then
+  cat "$stderr_file" >&2
+  exit 1
+fi
+
+if command -v zsh >/dev/null 2>&1; then
+  echo "Checking zsh startup with unknown Ghostty terminfo..."
+  rm -f "$stderr_file"
+  mkdir -p "$tmp_home/.oh-my-zsh"
+  touch "$tmp_home/.oh-my-zsh/oh-my-zsh.sh"
+  cp ./config/dotfiles/mac/zshrc.sh "$tmp_home/.zshrc"
+  cp ./config/dotfiles/mac/bashrc.sh "$tmp_home/.bashrc"
+  cp ./config/dotfiles/mac/config_vars.sh "$tmp_home/.config_vars"
+  cp ./config/dotfiles/mac/utility_aliases.sh "$tmp_home/.utility_aliases"
+  cp ./config/dotfiles/mac/splash_screens.sh "$tmp_home/.splash_screens"
+  sed -i.bak 's/local SPLASH_COMMAND=.*/local SPLASH_COMMAND=wolf/' "$tmp_home/.bashrc"
+
+  HOME="$tmp_home" \
+  PATH="$tmp_bin:$PATH" \
+  TERM=xterm-ghostty \
+  zsh -i -c exit >/dev/null 2>"$stderr_file"
+
+  if [ -s "$stderr_file" ]; then
+    cat "$stderr_file" >&2
+    exit 1
+  fi
+
+  echo "Checking zsh splash clear with missing terminfo fallback..."
+  rm -f "$stderr_file"
+  printf '%s\n' 'DISABLE_NERD_FONT_ICONS=false' > "$tmp_home/.config_vars"
+
+  HOME="$tmp_home" \
+  PATH="$tmp_bin:$PATH" \
+  TERM=xterm-ghostty \
+  zsh -i -c exit >/dev/null 2>"$stderr_file"
+
+  if [ -s "$stderr_file" ]; then
+    cat "$stderr_file" >&2
+    exit 1
+  fi
+fi

--- a/config/dotfiles/mac/bashrc.sh
+++ b/config/dotfiles/mac/bashrc.sh
@@ -5,10 +5,12 @@ source ~/.splash_screens
 # This file is processed on each interactive invocation of bash
 
 # Custom binding Overrides to use Ctrl+WASD to move around the terminal line
-bind '"\C-a": backward-word'
-bind '"\C-d": forward-word' # Note Ctrl+D is EOF, so this is a bit of a misnomer to override
-bind '"\C-s": beginning-of-line'
-bind '"\C-w": end-of-line'
+if [ -n "${BASH_VERSION:-}" ]; then
+  bind '"\C-a": backward-word'
+  bind '"\C-d": forward-word' # Note Ctrl+D is EOF, so this is a bit of a misnomer to override
+  bind '"\C-s": beginning-of-line'
+  bind '"\C-w": end-of-line'
+fi
 
 # Avoid problems with scp -- don't process the rest of the file if non-interactive
 [[ $- != *i* ]] && return
@@ -110,11 +112,29 @@ if [[ $(echo $BASH_VERSION) ]]; then
   fi
 fi
 
+splashClearScreen() {
+  if command -v clear >/dev/null 2>&1; then
+    if clear 2>/dev/null; then
+      return
+    fi
+
+    case "${TERM:-}" in
+      xterm-ghostty|ghostty)
+        if TERM=xterm-256color clear 2>/dev/null; then
+          return
+        fi
+        ;;
+    esac
+  fi
+
+  printf '\033[H\033[2J'
+}
+
 splash_screen() {
-  clear
+  splashClearScreen
   local SPLASH_COMMAND=
-  if type $SPLASH_COMMAND >/dev/null; then
-    $SPLASH_COMMAND
+  if [ -n "$SPLASH_COMMAND" ] && type "$SPLASH_COMMAND" >/dev/null 2>&1; then
+    "$SPLASH_COMMAND"
   fi
 }
 

--- a/config/dotfiles/mac/config_vars.sh
+++ b/config/dotfiles/mac/config_vars.sh
@@ -1,2 +1,15 @@
 # Disables PS1 Prompt and 'ls' command usage of nerd font icons
 DISABLE_NERD_FONT_ICONS=false
+
+macsetupUseFallbackTerminfo() {
+  case "${TERM:-}" in
+    xterm-ghostty|ghostty)
+      if command -v tput >/dev/null 2>&1 && ! tput cols >/dev/null 2>&1; then
+        TERM=xterm-256color
+        export TERM
+      fi
+      ;;
+  esac
+}
+
+macsetupUseFallbackTerminfo

--- a/config/dotfiles/mac/splash_screens.sh
+++ b/config/dotfiles/mac/splash_screens.sh
@@ -1,3 +1,30 @@
+splashTerminalColumns() {
+  local terminal_columns=""
+
+  if command -v tput >/dev/null 2>&1 && [ "${TERM:-dumb}" != "dumb" ]; then
+    terminal_columns="$(tput cols 2>/dev/null || true)"
+  fi
+
+  case "$terminal_columns" in
+    ''|*[!0-9]*)
+      terminal_columns="${COLUMNS:-80}"
+      ;;
+  esac
+
+  case "$terminal_columns" in
+    ''|*[!0-9]*)
+      terminal_columns=80
+      ;;
+  esac
+
+  printf '%s' "$terminal_columns"
+}
+
+splashHorizontalRow() {
+  local terminal_columns="$1"
+  printf '%*s\n' "$terminal_columns" '' | tr ' ' ─
+}
+
 wolf() {
   IFS='' read -r -d '' WOLF <<'EOF'
                                __
@@ -29,12 +56,14 @@ wolf() {
 EOF
   rainbowtext "$WOLF" -S 35
   # Print a horizontal divider
-  COLUMNS=$(tput cols)
-  HORIZONTAL_ROW=$(printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' ─)
-  if [ $COLUMNS -gt 200 ]; then
-    rainbowtext $HORIZONTAL_ROW -S 48 -p 10.0
+  local SPLASH_COLUMNS
+  local HORIZONTAL_ROW
+  SPLASH_COLUMNS="$(splashTerminalColumns)"
+  HORIZONTAL_ROW="$(splashHorizontalRow "$SPLASH_COLUMNS")"
+  if [ "$SPLASH_COLUMNS" -gt 200 ]; then
+    rainbowtext "$HORIZONTAL_ROW" -S 48 -p 10.0
   else
-    rainbowtext $HORIZONTAL_ROW -S 48 -p 7.0
+    rainbowtext "$HORIZONTAL_ROW" -S 48 -p 7.0
   fi
 }
 
@@ -71,7 +100,7 @@ mcc() {
 
 EOF
   # Only print graphical logo if we have all the means to display it properly
-  if cmdExists viu && [ -f ~/mcc_logo.png ] && [[ $TERM_PROGRAM == "iTerm.app" ]]; then
+  if cmdExists viu && [ -f ~/mcc_logo.png ] && [[ ${TERM_PROGRAM:-} == "iTerm.app" ]]; then
     viu ~/mcc_logo.png -h 7
   else
     rainbowtext "$MCC"
@@ -111,11 +140,13 @@ charizard() {
 EOF
   rainbowtext "$CHARIZARD" -S 35
   # Print a horizontal divider
-  COLUMNS=$(tput cols)
-  HORIZONTAL_ROW=$(printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' ─)
-  if [ $COLUMNS -gt 200 ]; then
-    rainbowtext $HORIZONTAL_ROW -S 48 -p 10.0
+  local SPLASH_COLUMNS
+  local HORIZONTAL_ROW
+  SPLASH_COLUMNS="$(splashTerminalColumns)"
+  HORIZONTAL_ROW="$(splashHorizontalRow "$SPLASH_COLUMNS")"
+  if [ "$SPLASH_COLUMNS" -gt 200 ]; then
+    rainbowtext "$HORIZONTAL_ROW" -S 48 -p 10.0
   else
-    rainbowtext $HORIZONTAL_ROW -S 48 -p 7.0
+    rainbowtext "$HORIZONTAL_ROW" -S 48 -p 7.0
   fi
 }

--- a/config/dotfiles/mac/utility_aliases.sh
+++ b/config/dotfiles/mac/utility_aliases.sh
@@ -40,7 +40,7 @@ termColors() {
 
 # Returns whether or not a command exists
 cmdExists() {
-  if hash $1 2>/dev/null; then
+  if [ "$#" -gt 0 ] && hash "$1" 2>/dev/null; then
     true
   else
     false
@@ -66,11 +66,13 @@ hlogs() {
 
 # Display text in rainbow if lolcat installed, else regular text
 rainbowtext() {
-  TEXT=$1 && shift
+  local TEXT="${1:-}"
+  [ "$#" -gt 0 ] && shift
+
   if cmdExists lolcat; then
-    printf "$TEXT" | lolcat "$@"
+    printf '%s' "$TEXT" | lolcat "$@"
   else
-    printf "$TEXT"
+    printf '%s' "$TEXT"
   fi
 }
 

--- a/config/dotfiles/mac/zshrc.sh
+++ b/config/dotfiles/mac/zshrc.sh
@@ -1,6 +1,8 @@
 # If you come from bash you might have to change your $PATH.
 #export PATH=$HOME/bin:/usr/local/bin:$PATH
 
+[ -f ~/.config_vars ] && source ~/.config_vars
+
 # Path to your oh-my-zsh installation.
 export ZSH=~/.oh-my-zsh
 

--- a/lib/macsetup/constants.sh
+++ b/lib/macsetup/constants.sh
@@ -5,17 +5,35 @@
 ################################
 
 # FONT COLORS
-RED=$(tput setaf 9)
-ORANGE=$(tput setaf 172)
-GREEN=$(tput setaf 2)
-BLUE=$(tput setaf 12)
-YELLOW=$(tput setaf 11)
-GRAY=$(tput setaf 8)
-LIGHT_GRAY=$(tput setaf 7)
+macsetupTput() {
+  local term_name="${TERM:-dumb}"
+
+  if ! command -v tput >/dev/null 2>&1 || [ "$term_name" = "dumb" ]; then
+    return 0
+  fi
+
+  if tput "$@" 2>/dev/null; then
+    return 0
+  fi
+
+  case "$term_name" in
+    xterm-ghostty|ghostty)
+      TERM=xterm-256color tput "$@" 2>/dev/null || true
+      ;;
+  esac
+}
+
+RED=$(macsetupTput setaf 9)
+ORANGE=$(macsetupTput setaf 172)
+GREEN=$(macsetupTput setaf 2)
+BLUE=$(macsetupTput setaf 12)
+YELLOW=$(macsetupTput setaf 11)
+GRAY=$(macsetupTput setaf 8)
+LIGHT_GRAY=$(macsetupTput setaf 7)
 HEADER_BLUE=$'\033[38;2;194;203;237m'
-BOLD=$(tput bold)
-DIM=$(tput dim)
-RESET_COLOR=$(tput sgr0)
+BOLD=$(macsetupTput bold)
+DIM=$(macsetupTput dim)
+RESET_COLOR=$(macsetupTput sgr0)
 
 UI_BOX_COLOR="${DIM}${LIGHT_GRAY}"
 UI_TITLE_COLOR="${BOLD}${HEADER_BLUE}"

--- a/sections/setup_asdf.sh
+++ b/sections/setup_asdf.sh
@@ -15,12 +15,12 @@ setupAsdf() {
   assertPackageInstallation asdf "asdf"
   cd "$currDir"
 
-  info "Configuring asdf version manager in .bash_profile and .zprofile"
-  addLineToFiles "" ~/.bash_profile ~/.zprofile
-  addLineToFiles "# asdf version manager" ~/.bash_profile ~/.zprofile
-  addLineToFiles '. $HOME/.asdf/asdf.sh' ~/.bash_profile ~/.zprofile
-  addLineToFiles '. $HOME/.asdf/completions/asdf.bash' ~/.bash_profile # This line does not apply to .zprofile
-  success 'Added asdf configuration to ~/.bash_profile and ~/.zprofile'
+  info "Configuring asdf version manager in shell startup files"
+  addLineToFiles "" ~/.bash_profile ~/.bashrc ~/.zprofile ~/.zshrc
+  addLineToFiles "# asdf version manager" ~/.bash_profile ~/.bashrc ~/.zprofile ~/.zshrc
+  addLineToFiles '. $HOME/.asdf/asdf.sh' ~/.bash_profile ~/.bashrc ~/.zprofile ~/.zshrc
+  addLineToFiles '. $HOME/.asdf/completions/asdf.bash' ~/.bash_profile ~/.bashrc
+  success 'Added asdf configuration to shell startup files'
 
   source ~/.bash_profile
   source ~/.zprofile


### PR DESCRIPTION
## Summary
- Silence installer color initialization when TERM has no local terminfo entry, with a Ghostty fallback to xterm-256color.
- Make splash screen width detection resilient to failed tput calls and quote rainbowtext output so lolcat flags are not treated as printf options.
- Guard the splash clear path so missing Ghostty terminfo cannot emit '\''xterm-ghostty'\'': unknown terminal type.
- Load asdf from interactive zsh startup files and avoid running Bash-only bind commands when .bashrc is sourced from zsh.
- Add shell startup regression coverage for TERM=xterm-ghostty, including a missing-fallback config case.

## Validation
- bash ./ci/test_shell_startup.sh
- bash ./ci/checks.sh
- git diff --check