### PR TITLE
[codex] Fix section footer border rendering

### DIFF
--- a/ci/test_ui.sh
+++ b/ci/test_ui.sh
@@ -95,6 +95,35 @@ MACSETUP_UI_ASCII=true TERM="${TERM:-xterm}" bash -c '
   ! printf "%s" "$output" | grep -q "=>"
 '
 
+echo "Checking rounded section footer preserves border..."
+MACSETUP_UI_FORCE_ROUNDED=true LANG= LC_ALL= LC_CTYPE= TERM="${TERM:-xterm}" bash -c '
+  source ./lib/macsetup/constants.sh
+  source ./lib/macsetup/helperFunctions.sh
+
+  MACSETUP_UI_TITLE="ASDF Version Manager"
+  MACSETUP_UI_FOOTER="Section 12/19"
+  output="$(uiRenderChoiceMenu "Proceed with section?" 0 "No" "Yes")"
+  expected_width=""
+  line_count=0
+  bottom_line=""
+
+  while IFS= read -r line; do
+    width="$(uiVisibleLength "$line")"
+    if [ -z "$expected_width" ]; then
+      expected_width="$width"
+    fi
+    [ "$width" = "$expected_width" ]
+    bottom_line="$line"
+    line_count=$((line_count + 1))
+  done <<< "$output"
+
+  [ "$line_count" -eq 7 ]
+  printf "%s" "$output" | grep -q "Section 12/19"
+  printf "%s" "$bottom_line" | grep -q "╰"
+  printf "%s" "$bottom_line" | grep -q "╯"
+  ! printf "%s" "$bottom_line" | grep -q "Section"
+'
+
 echo "Checking forced rounded UI rendering..."
 MACSETUP_UI_FORCE_ROUNDED=true LANG= LC_ALL= LC_CTYPE= TERM="${TERM:-xterm}" bash -c '
   source ./lib/macsetup/constants.sh

--- a/lib/macsetup/ui.sh
+++ b/lib/macsetup/ui.sh
@@ -18,6 +18,18 @@ uiVisibleLength() {
   local esc=$'\033'
 
   text="$(printf '%s' "$text" | sed "s/${esc}(B//g; s/${esc}\\[[0-9;]*[[:alpha:]]//g")"
+
+  # Bash counts bytes instead of characters when the locale is not UTF-8. The
+  # TUI still uses these glyphs in known Unicode-capable terminals, so normalize
+  # framework-owned glyphs to single-byte placeholders before measuring.
+  text="${text//╭/x}"
+  text="${text//╮/x}"
+  text="${text//╰/x}"
+  text="${text//╯/x}"
+  text="${text//─/x}"
+  text="${text//│/x}"
+  text="${text//▶/x}"
+
   echo "${#text}"
 }
 
@@ -266,12 +278,13 @@ uiMenuLineCount() {
     count=$((count + 2))
   fi
 
+  if [ -n "${MACSETUP_UI_FOOTER:-}" ]; then
+    count=$((count + 1))
+  fi
+
   uiSetBoxChars
   if [ "$MACSETUP_UI_BOX_STYLE" = "ascii" ]; then
     count=$((count + 1))
-    if [ -n "${MACSETUP_UI_FOOTER:-}" ]; then
-      count=$((count + 1))
-    fi
   fi
 
   echo "$count"
@@ -331,8 +344,6 @@ uiPrintBoxFooterLine() {
 uiPrintBoxBottom() {
   local content_width="$1"
   local footer="${MACSETUP_UI_FOOTER:-}"
-  local footer_width=0
-  local fill_width=0
 
   if [ "$MACSETUP_UI_BOX_STYLE" = "ascii" ]; then
     if [ -n "$footer" ]; then
@@ -345,21 +356,13 @@ uiPrintBoxBottom() {
     return
   fi
 
-  if [ -z "$footer" ]; then
-    printf '%b%s' "$UI_BOX_COLOR" "$MACSETUP_UI_BOX_BL"
-    uiRepeat "$MACSETUP_UI_BOX_H" "$((content_width + 2))"
-    printf '%s%b\n' "$MACSETUP_UI_BOX_BR" "$RESET_COLOR"
-    return
+  if [ -n "$footer" ]; then
+    uiPrintBoxFooterLine "$footer" "$content_width"
   fi
-
-  footer_width="$(uiVisibleLength "$footer")"
-  fill_width=$((content_width - footer_width - 1))
 
   printf '%b%s' "$UI_BOX_COLOR" "$MACSETUP_UI_BOX_BL"
-  if [ "$fill_width" -gt 0 ]; then
-    uiRepeat "$MACSETUP_UI_BOX_H" "$fill_width"
-  fi
-  printf ' %b%s%b%b %s%s%b\n' "$UI_FOOTER_COLOR" "$footer" "$RESET_COLOR" "$UI_BOX_COLOR" "$MACSETUP_UI_BOX_H" "$MACSETUP_UI_BOX_BR" "$RESET_COLOR"
+  uiRepeat "$MACSETUP_UI_BOX_H" "$((content_width + 2))"
+  printf '%s%b\n' "$MACSETUP_UI_BOX_BR" "$RESET_COLOR"
 }
 
 uiRenderChoiceMenu() {


### PR DESCRIPTION
## Summary
- Move the section footer out of the rounded bottom border and into a right-aligned interior row.
- Keep the bottom border continuous so narrow section boxes do not look broken.
- Normalize framework-owned Unicode glyphs before measuring visible line width so selected rows with the ▶ pointer align even when the shell locale is not UTF-8.
- Update UI line counting for footer rows and add a regression test for the ASDF section menu.

## Validation
- bash ./ci/test_ui.sh
- bash ./ci/checks.sh
- git diff --check