### PR TITLE
[codex] Improve asdf error logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ installer remains scriptable and portable.
 
 ## Diagnostics
 
+Installer runs write a summary log to `~/.mac_setup/log`. Interactive output is
+kept concise, while failed command details such as command text, exit code,
+stdout, and stderr are written to the log for debugging.
+
 To compare the current machine's managed top-level dotfiles against the repo
 configuration, run:
 

--- a/ci/checks.sh
+++ b/ci/checks.sh
@@ -24,6 +24,9 @@ bash ./ci/test_ui.sh
 echo "Checking shell startup helpers..."
 bash ./ci/test_shell_startup.sh
 
+echo "Checking command failure logging..."
+bash ./ci/test_command_logging.sh
+
 echo "Checking install.sh skipped-section path with isolated HOME..."
 tmp_home="$(mktemp -d)"
 cleanup() {

--- a/ci/test_command_logging.sh
+++ b/ci/test_command_logging.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$repo_root"
+
+tmp_home="$(mktemp -d)"
+tmp_output="$(mktemp)"
+tmp_stderr="$(mktemp)"
+cleanup() {
+  rm -rf "$tmp_home"
+  rm -f "$tmp_output" "$tmp_stderr"
+}
+trap cleanup EXIT
+
+echo "Checking command failure details are logged..."
+HOME="$tmp_home" TERM="${TERM:-xterm}" bash -c '
+  source ./lib/macsetup/constants.sh
+  source ./lib/macsetup/helperFunctions.sh
+
+  mkdir -p "$ROOT_MAC_SETUP_FOLDER"
+
+  if runCommand "Run failing probe command" bash -c "printf \"%s\n\" stdout-line; printf \"%s\n\" stderr-line >&2; exit 42"; then
+    exit 1
+  fi
+
+  test "${#FAILURES_ARRAY[@]}" -eq 1
+
+  generateLog
+' > "$tmp_output" 2> "$tmp_stderr"
+
+log_path="$tmp_home/.mac_setup/log"
+
+grep -q "Run failing probe command failed" "$tmp_output"
+! grep -q "    Exit code: 42" "$tmp_output"
+! grep -q "      stdout-line" "$tmp_output"
+! grep -q "      stderr-line" "$tmp_output"
+! grep -q "Command: bash -c" "$tmp_output"
+test ! -s "$tmp_stderr"
+
+grep -qFx "    Exit code: 42" "$log_path"
+grep -qFx "      stdout-line" "$log_path"
+grep -qFx "      stderr-line" "$log_path"
+grep -q "Command: bash -c" "$log_path"
+
+echo "Checking command output can be captured without losing failure logs..."
+HOME="$tmp_home" TERM="${TERM:-xterm}" bash -c '
+  source ./lib/macsetup/constants.sh
+  source ./lib/macsetup/helperFunctions.sh
+
+  mkdir -p "$ROOT_MAC_SETUP_FOLDER"
+
+  runCommandOutputVariable captured_value "Capture probe command output" bash -c "printf \"%s\" captured"
+  test "$captured_value" = "captured"
+
+  if runCommandOutputVariable failed_value "Capture failing probe command output" bash -c "printf \"%s\n\" captured-stdout; printf \"%s\n\" captured-stderr >&2; exit 64"; then
+    exit 1
+  fi
+
+  generateLog
+
+  grep -qFx "    Exit code: 64" "$LOG_PATH"
+  grep -qFx "      captured-stdout" "$LOG_PATH"
+  grep -qFx "      captured-stderr" "$LOG_PATH"
+' > "$tmp_output" 2> "$tmp_stderr"
+
+grep -q "Capture failing probe command output failed" "$tmp_output"
+! grep -q "captured-stdout" "$tmp_output"
+! grep -q "captured-stderr" "$tmp_output"
+test ! -s "$tmp_stderr"
+
+echo "Checking exploratory probe failures only write to the log..."
+HOME="$tmp_home" TERM="${TERM:-xterm}" bash -c '
+  source ./lib/macsetup/constants.sh
+  source ./lib/macsetup/helperFunctions.sh
+
+  mkdir -p "$ROOT_MAC_SETUP_FOLDER"
+
+  runProbeCommandOutputVariable probe_value "Probe successful command" bash -c "printf \"%s\" probe-value"
+  test "$probe_value" = "probe-value"
+
+  if runProbeCommandOutputVariable failed_probe_value "Probe failing command" bash -c "printf \"%s\n\" probe-stdout; printf \"%s\n\" probe-stderr >&2; exit 70"; then
+    exit 1
+  fi
+
+  test "${#FAILURES_ARRAY[@]}" -eq 0
+  generateLog
+
+  grep -qFx "    Probe failed: Probe failing command" "$LOG_PATH"
+  grep -qFx "    Exit code: 70" "$LOG_PATH"
+  grep -qFx "      probe-stdout" "$LOG_PATH"
+  grep -qFx "      probe-stderr" "$LOG_PATH"
+' > "$tmp_output" 2> "$tmp_stderr"
+
+! grep -q "Probe failing command" "$tmp_output"
+! grep -q "probe-stdout" "$tmp_output"
+! grep -q "probe-stderr" "$tmp_output"
+test ! -s "$tmp_stderr"

--- a/ci/test_installers.sh
+++ b/ci/test_installers.sh
@@ -31,6 +31,11 @@ case "$1" in
     echo "tap $2" >> "$BREW_LOG"
     ;;
   install)
+    if [ "$2" = "broken-formula" ]; then
+      echo "brew stdout-line"
+      echo "brew stderr-line" >&2
+      exit 55
+    fi
     echo "install $2" >> "$BREW_LOG"
     touch "$BREW_STATE/formula-$2"
     cat > "$TMP_BIN/probe-command" <<'COMMAND'
@@ -68,5 +73,95 @@ bash -c '
   test "$(grep -cFx "tap example/tap" "$BREW_LOG")" -eq 1
   test "$(grep -cFx "install probe-formula" "$BREW_LOG")" -eq 1
   test "$(grep -cFx "configure probe" "$BREW_LOG")" -eq 2
+  test "${#FAILURES_ARRAY[@]}" -eq 0
+'
+
+echo "Checking Homebrew package failures are detailed in the log only..."
+failure_output="$tmp_state/brew-failure.out"
+HOME="$tmp_home" \
+PATH="$tmp_bin:$PATH" \
+TERM="${TERM:-xterm}" \
+BREW_LOG="$brew_log" \
+BREW_STATE="$tmp_state" \
+TMP_BIN="$tmp_bin" \
+bash -c '
+  source ./lib/macsetup/constants.sh
+  source ./lib/macsetup/helperFunctions.sh
+  set -euo pipefail
+
+  mkdir -p "$ROOT_MAC_SETUP_FOLDER"
+
+  if installHomebrewPackage "Broken Package" "broken-formula" ""; then
+    exit 1
+  fi
+
+  test "${#FAILURES_ARRAY[@]}" -eq 1
+  generateLog
+' > "$failure_output"
+
+grep -q "Install Homebrew package Broken Package failed" "$failure_output"
+! grep -q "brew stdout-line" "$failure_output"
+! grep -q "brew stderr-line" "$failure_output"
+
+grep -qFx "    Exit code: 55" "$tmp_home/.mac_setup/log"
+grep -qFx "      brew stdout-line" "$tmp_home/.mac_setup/log"
+grep -qFx "      brew stderr-line" "$tmp_home/.mac_setup/log"
+
+cat > "$tmp_bin/asdf" <<'ASDF'
+#!/bin/bash
+
+set -euo pipefail
+
+case "$1" in
+  plugin)
+    if [ "$2" = "list" ]; then
+      find "$BREW_STATE" -name "asdf-plugin-*" -type f -exec basename {} \; | sed "s/^asdf-plugin-//"
+      exit 0
+    fi
+    exit 2
+    ;;
+  plugin-add)
+    echo "plugin-add $2" >> "$BREW_LOG"
+    touch "$BREW_STATE/asdf-plugin-$2"
+    ;;
+  install)
+    echo "install $2" >> "$BREW_LOG"
+    case "$2" in
+      nodejs)
+        cat > "$TMP_BIN/node" <<'NODE'
+#!/bin/sh
+exit 0
+NODE
+        chmod +x "$TMP_BIN/node"
+        ;;
+    esac
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+ASDF
+chmod +x "$tmp_bin/asdf"
+
+echo "Checking asdf package helper install and rerun behavior..."
+HOME="$tmp_home" \
+PATH="$tmp_bin:$PATH" \
+TERM="${TERM:-xterm}" \
+BREW_LOG="$brew_log" \
+BREW_STATE="$tmp_state" \
+TMP_BIN="$tmp_bin" \
+bash -c '
+  source ./lib/macsetup/constants.sh
+  source ./lib/macsetup/helperFunctions.sh
+  set -euo pipefail
+
+  : > "$BREW_LOG"
+  printf "%s\n" "nodejs 22.0.0" > "$HOME/.tool-versions"
+
+  installAsdfToolFromToolVersions "nodejs" "Node" "node"
+  installAsdfToolFromToolVersions "nodejs" "Node" "node"
+
+  test "$(grep -cFx "plugin-add nodejs" "$BREW_LOG")" -eq 1
+  test "$(grep -cFx "install nodejs" "$BREW_LOG")" -eq 2
   test "${#FAILURES_ARRAY[@]}" -eq 0
 '

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,42 @@ desired machine state it applies.
 Framework code should avoid knowing the details of a specific machine
 preference unless it is needed to apply or verify configuration.
 
+### Command Logging
+
+Shell-outs should use the command helpers in `lib/macsetup/logging.sh` instead
+of running commands directly. The installer should keep terminal output concise
+while writing detailed command diagnostics to `~/.mac_setup/log` when something
+fails.
+
+- `runCommand "Description" command args...`
+  Use for non-interactive commands whose normal output is not useful unless the
+  command fails, such as `cp`, `git clone`, `brew install`, and `asdf install`.
+  On failure, the terminal shows a short failure line and the log captures the
+  command, exit code, stdout, and stderr.
+- `runCommandCapture "Description" "$output_file" command args...`
+  Use when a later step needs stdout in a file. The failure logging behavior is
+  the same as `runCommand`.
+- `runCommandOutputVariable variable_name "Description" command args...`
+  Use instead of command substitution when stdout should be assigned to a
+  variable, such as `brew --prefix` or `ssh-agent -s`. This preserves detailed
+  failure logging.
+- `runProbeCommandOutputVariable variable_name "Description" command args...`
+  Use for exploratory path probes where failure should not print to the
+  terminal or count toward the final failure summary because a later candidate
+  may succeed. Failed probes still write command details to the log.
+- `runInteractiveCommand "Description" command args...`
+  Use for commands that may prompt, consume stdin, or manage their own terminal
+  output, such as native installers or `ssh-keygen`. Failure logs include the
+  command and exit code, but stdout/stderr are not captured.
+- `runOptionalCommand "Description" command args...`
+  Use for cleanup or advisory commands where failure should be a warning, not a
+  section failure. Captured stdout/stderr still go to the log when the command
+  fails.
+
+If a command is purely a local predicate and its output is intentionally
+discarded, direct execution is acceptable. Examples include `cmdExists`,
+`grep -q`, and package-installed checks.
+
 ## Sections
 
 `sections/` contains the installer workflow. Each section defines `runSection`

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ source "$(scriptDirectory)/lib/macsetup/appConfigUtil.sh"
 # Main Function
 function main {
   # Create root setup folder
-  mkdir -p $ROOT_MAC_SETUP_FOLDER
+  runCommand "Create MacSetup root folder" mkdir -p "$ROOT_MAC_SETUP_FOLDER" || exit 1
 
   # Print out the intro message
   printIntro

--- a/lib/macsetup/appConfigUtil.sh
+++ b/lib/macsetup/appConfigUtil.sh
@@ -6,7 +6,8 @@
 
 configureICU4C() {
   info "Configuring icu4c"
-  ICU_PATH=$(brew --prefix icu4c)
+  local ICU_PATH=""
+  runCommandOutputVariable ICU_PATH "Find Homebrew prefix for icu4c" brew --prefix icu4c || return 1
   # Add To Path
   addLineToFiles "" ~/.bash_profile ~/.zprofile
   addLineToFiles "# Add icu4c to path" ~/.bash_profile ~/.zprofile
@@ -29,7 +30,8 @@ configureICU4C() {
 
 configureOpenSSL() {
   info "Configuring openssl"
-  OPEN_SSL_PATH=$(brew --prefix openssl)
+  local OPEN_SSL_PATH=""
+  runCommandOutputVariable OPEN_SSL_PATH "Find Homebrew prefix for openssl" brew --prefix openssl || return 1
   # Add To Path
   addLineToFiles "" ~/.bash_profile ~/.zprofile
   addLineToFiles "# Add openssl to path" ~/.bash_profile ~/.zprofile
@@ -59,8 +61,7 @@ configureBat() {
 
   if cmdExists bat; then
     local bat_config_dir
-    if ! bat_config_dir="$(bat --config-dir)"; then
-      fail "Cannot configure bat. Failed to determine bat config directory"
+    if ! runCommandOutputVariable bat_config_dir "Determine bat config directory" bat --config-dir; then
       return
     fi
 
@@ -74,18 +75,15 @@ configureBat() {
       return
     fi
 
-    mkdir -p "$bat_theme_dir"
-    if ! cp "$bat_theme_source" "$bat_theme_destination"; then
-      fail "Failed to copy bat theme: $bat_theme_name"
-      return
-    fi
+    runCommand "Create bat theme directory" mkdir -p "$bat_theme_dir" || return 1
+    runCommand "Copy bat theme $bat_theme_name" cp "$bat_theme_source" "$bat_theme_destination" || return 1
 
     assertFileExists "$bat_theme_destination" "bat theme installed: $bat_theme_name" "Failed to install bat theme: $bat_theme_name"
 
-    if bat cache --build; then
+    if runCommand "Rebuild bat cache" bat cache --build; then
       success "bat cache rebuilt"
     else
-      fail "Failed to rebuild bat cache"
+      return 1
     fi
   else
     fail "Cannot configure bat because it is not installed"
@@ -107,9 +105,10 @@ configureVSCode() {
     info "Installing VSCode Packages"
     if cmdExists code; then
       # For every non-blank line
-      for extension in `grep -v "^$" "$MACSETUP_CONFIG_DIR/vscode/default/extensions.list"`; do
-        code --install-extension $extension
-      done
+      while IFS= read -r extension || [ -n "$extension" ]; do
+        [ -z "$extension" ] && continue
+        runCommand "Install VSCode extension $extension" code --install-extension "$extension" || return 1
+      done < "$MACSETUP_CONFIG_DIR/vscode/default/extensions.list"
 
       info 'Adding VSCode to $PATH'
       addLineToFiles "" ~/.bash_profile ~/.zprofile
@@ -119,7 +118,7 @@ configureVSCode() {
       info 'Setting settings.json file'
       SETTINGS_PATH=~/Library/'Application Support'/Code/User/settings.json
       if [ -f "$SETTINGS_PATH" ]; then
-        cp "$MACSETUP_CONFIG_DIR/vscode/default/settings.json" "$SETTINGS_PATH"
+        runCommand "Copy VSCode settings.json" cp "$MACSETUP_CONFIG_DIR/vscode/default/settings.json" "$SETTINGS_PATH" || return 1
         assertFileExists "$SETTINGS_PATH" "Successfully updated settings.json file" "Could not update settings.json file"
       else
         warn "Could not automatically copy over settings.json"
@@ -138,15 +137,11 @@ configureRectangle() {
   info "Configuring Rectangle"
   if [ -d "/Applications/Rectangle.app" ]; then
     info "Setting up shortcut preferences"
-    # Preserve white space by changing the Internal Field Separator
-    IFS='%'
-    mkdir -p ~/Library/'Application Support'/Rectangle
-    cp "$MACSETUP_CONFIG_DIR/apps/rectangle/com.knollsoft.Rectangle.plist" ~/Library/Preferences/com.knollsoft.Rectangle.plist
+    runCommand "Create Rectangle application support directory" mkdir -p ~/Library/'Application Support'/Rectangle || return 1
+    runCommand "Copy Rectangle preferences" cp "$MACSETUP_CONFIG_DIR/apps/rectangle/com.knollsoft.Rectangle.plist" ~/Library/Preferences/com.knollsoft.Rectangle.plist || return 1
     assertFileExists ~/Library/Preferences/com.knollsoft.Rectangle.plist "Rectangle Shortcuts set" "Failed to set Rectangle Shortcuts"
-    # Reset the Internal Field Separator
-    unset IFS
     info "Opening Rectangle.app"
-    open /Applications/Rectangle.app
+    runCommand "Open Rectangle.app" open /Applications/Rectangle.app || return 1
   else
     fail "Cannot configure Rectangle as it is not installed"
   fi
@@ -157,13 +152,13 @@ configureITerm() {
   if [ -d "/Applications/iTerm.app" ]; then
     # Delete cached preferences
     info "Deleting cached iTerm preferences"
-    defaults delete com.googlecode.iterm2
+    runOptionalCommand "Delete cached iTerm preferences" defaults delete com.googlecode.iterm2 || true
     # Copying over new configurations file
     info "Setting iTerm configurations file in ~/Library/Preferences/"
-    cp "$MACSETUP_CONFIG_DIR/terminal/iterm2/com.googlecode.iterm2.plist" ~/Library/Preferences/com.googlecode.iterm2.plist
+    runCommand "Copy iTerm preferences" cp "$MACSETUP_CONFIG_DIR/terminal/iterm2/com.googlecode.iterm2.plist" ~/Library/Preferences/com.googlecode.iterm2.plist || return 1
     # Reading in new config file
     info "Reading in new configurations file"
-    `defaults read -app iTerm` 2>/dev/null
+    runOptionalCommand "Read iTerm defaults" defaults read -app iTerm || true
     # Assert configuration file was copied over successfully
     assertFileExists ~/Library/Preferences/"com.googlecode.iterm2.plist" "iTerm config file set correctly" "Failed to set iTerm config file"
   else

--- a/lib/macsetup/backup.sh
+++ b/lib/macsetup/backup.sh
@@ -18,7 +18,7 @@ backupFile() {
   local suffix=""
   local new_file=""
 
-  mkdir -p "$BACKUP_DIRECTORY"
+  runCommand "Create backup directory $BACKUP_DIRECTORY" mkdir -p "$BACKUP_DIRECTORY" || return 1
 
   if [ ! -f "$original_path" ]; then
     warn "$original_path Does not exist, skipping backup..."
@@ -27,10 +27,10 @@ backupFile() {
     suffix="__$(date +'%s')"
     new_file="$BACKUP_DIRECTORY/$date_folder/$new_file_name$suffix"
     if [ ! -d "$new_file" ]; then
-      mkdir -p "$new_file"
+      runCommand "Create backup destination $new_file" mkdir -p "$new_file" || return 1
     fi
 
-    cp "$original_path" "$new_file"
+    runCommand "Back up file $original_path" cp "$original_path" "$new_file" || return 1
     if [ -a "$new_file" ]; then
       success "Backed up $original_path to $new_file"
     else
@@ -46,7 +46,7 @@ backupDir() {
   local suffix=""
   local new_dir=""
 
-  mkdir -p "$BACKUP_DIRECTORY"
+  runCommand "Create backup directory $BACKUP_DIRECTORY" mkdir -p "$BACKUP_DIRECTORY" || return 1
 
   if [ ! -d "$original_path" ]; then
     warn "$original_path Does not exist, skipping backup..."
@@ -55,10 +55,10 @@ backupDir() {
     suffix="__$(date +'%s')"
     new_dir="$BACKUP_DIRECTORY/$date_folder/$new_directory_name$suffix"
     if [ ! -d "$new_dir" ]; then
-      mkdir -p "$new_dir"
+      runCommand "Create backup destination $new_dir" mkdir -p "$new_dir" || return 1
     fi
 
-    cp -r "$original_path" "$new_dir"
+    runCommand "Back up directory $original_path" cp -r "$original_path" "$new_dir" || return 1
     if [ -d "$new_dir" ]; then
       success "Backed up directory $original_path to $new_dir"
     else
@@ -76,7 +76,7 @@ addLineToFiles() {
   line="$(macsetupManagedLine "$text")"
 
   for file in "${files_arr[@]}"; do
-    ensureLineInFile "$line" "$file"
+    ensureLineInFile "$line" "$file" || return 1
   done
 }
 
@@ -94,7 +94,7 @@ ensureLineInFile() {
   local line="$1"
   local file="$2"
 
-  touch "$file"
+  runCommand "Ensure editable file exists at $file" touch "$file" || return 1
 
   if [ -z "$line" ]; then
     return 0
@@ -104,7 +104,7 @@ ensureLineInFile() {
     return 0
   fi
 
-  echo "$line" >> "$file"
+  runCommand "Append managed line to $file" bash -c 'printf "%s\n" "$1" >> "$2"' _ "$line" "$file"
 }
 
 removeManagedBlock() {
@@ -114,16 +114,22 @@ removeManagedBlock() {
   local start_marker="# >>> MacSetup: $block_name"
   local end_marker="# <<< MacSetup: $block_name"
 
-  touch "$file"
+  runCommand "Ensure editable file exists at $file" touch "$file" || return 1
   tmp_file="$(mktemp)"
 
-  awk -v start="$start_marker" -v end="$end_marker" '
+  runCommand "Remove managed block $block_name from $file" bash -c 'awk -v start="$1" -v end="$2" '"'"'
     $0 == start { skipping = 1; next }
     $0 == end { skipping = 0; next }
     !skipping { print }
-  ' "$file" > "$tmp_file"
+  '"'"' "$3" > "$4"' _ "$start_marker" "$end_marker" "$file" "$tmp_file" || {
+    rm -f "$tmp_file"
+    return 1
+  }
 
-  mv "$tmp_file" "$file"
+  runCommand "Replace managed block file $file" mv "$tmp_file" "$file" || {
+    rm -f "$tmp_file"
+    return 1
+  }
 }
 
 ensureManagedBlock() {
@@ -132,13 +138,19 @@ ensureManagedBlock() {
   shift 2
   local line=""
 
-  removeManagedBlock "$block_name" "$file"
+  removeManagedBlock "$block_name" "$file" || return 1
 
-  {
-    echo "# >>> MacSetup: $block_name"
-    for line in "$@"; do
-      echo "$line"
-    done
-    echo "# <<< MacSetup: $block_name"
-  } >> "$file"
+  runCommand "Append managed block $block_name to $file" bash -c '
+    file="$1"
+    block_name="$2"
+    shift 2
+
+    {
+      printf "%s\n" "# >>> MacSetup: $block_name"
+      for line in "$@"; do
+        printf "%s\n" "$line"
+      done
+      printf "%s\n" "# <<< MacSetup: $block_name"
+    } >> "$file"
+  ' _ "$file" "$block_name" "$@"
 }

--- a/lib/macsetup/installers.sh
+++ b/lib/macsetup/installers.sh
@@ -20,13 +20,11 @@ installHomebrewPackage() {
   if brewPackageInstalled "$formula"; then
     info "$display_name is already installed"
   else
-    if [ -n "$tap" ] && ! brew tap "$tap"; then
-      fail "Failed to tap Homebrew repository: $tap"
+    if [ -n "$tap" ] && ! runCommand "Tap Homebrew repository $tap" brew tap "$tap"; then
       return 1
     fi
 
-    if ! brew install "$formula"; then
-      fail "Failed to install Homebrew package: $display_name"
+    if ! runCommand "Install Homebrew package $display_name" brew install "$formula"; then
       return 1
     fi
   fi
@@ -66,6 +64,52 @@ caskInstallAppsFromList() {
   done
 }
 
+asdfPluginInstalled() {
+  local plugin_name="$1"
+  asdf plugin list 2>/dev/null | grep -qx "$plugin_name"
+}
+
+ensureAsdfPlugin() {
+  local plugin_name="$1"
+  local display_name="$2"
+  local plugin_url="${3:-}"
+
+  if asdfPluginInstalled "$plugin_name"; then
+    info "$display_name asdf plugin is already added"
+    return 0
+  fi
+
+  if [ -n "$plugin_url" ]; then
+    runCommand "Add $display_name asdf plugin" asdf plugin-add "$plugin_name" "$plugin_url"
+  else
+    runCommand "Add $display_name asdf plugin" asdf plugin-add "$plugin_name"
+  fi
+}
+
+installAsdfToolFromToolVersions() {
+  local plugin_name="$1"
+  local display_name="$2"
+  local assertion_command="$3"
+  local plugin_url="${4:-}"
+
+  if ! cmdExists asdf; then
+    fail "Failed to install $display_name. \`asdf\` is required to install."
+    return 1
+  fi
+
+  if [ ! -f ~/.tool-versions ]; then
+    fail "~/.tool-versions not found, cannot install $display_name via \`asdf\`."
+    return 1
+  fi
+
+  success "Found ~/.tool-versions file"
+  ensureAsdfPlugin "$plugin_name" "$display_name" "$plugin_url" || return 1
+
+  info "Installing $display_name from ~/.tool-versions: "$'\n'"---TOOLS---"$'\n'"$(cat ~/.tool-versions)"$'\n'"-----------"
+  runCommand "Install $display_name with asdf" asdf install "$plugin_name" || return 1
+  assertPackageInstallation "$assertion_command" "$display_name"
+}
+
 caskInstallAppPrompt() {
   local app_name="$1"
   local cask_name="$2"
@@ -79,8 +123,8 @@ caskInstallAppPrompt() {
       warn "$app_name is already installed. Prompting overwrite..."
       promptYesNo "Do you want to $RED OVERWRITE $RESET_COLOR application $app_name?"
       if [[ $REPLY =~ ^[Yy]$ ]]; then
-        rm -rf "/Applications/$app_name"
-        brew reinstall --cask "$cask_name"
+        runCommand "Remove existing application $app_name" rm -rf "/Applications/$app_name" || return 1
+        runCommand "Reinstall Homebrew cask $cask_name" brew reinstall --cask "$cask_name" || return 1
         if [ -n "$configure_function" ]; then
           "$configure_function"
         fi
@@ -88,7 +132,7 @@ caskInstallAppPrompt() {
         info "Skipping overwrite..."
       fi
     else
-      brew install --cask "$cask_name"
+      runCommand "Install Homebrew cask $cask_name" brew install --cask "$cask_name" || return 1
       if [ -n "$configure_function" ]; then
         "$configure_function"
       fi

--- a/lib/macsetup/logging.sh
+++ b/lib/macsetup/logging.sh
@@ -12,6 +12,284 @@ logEntry() {
   LOG_ARRAY+=("$msg")
 }
 
+# Render a command as a copyable shell-like string for failure logs.
+# Accepts command argv exactly as it will be executed.
+formatCommandForLog() {
+  local formatted=""
+  local quoted_arg=""
+  local arg=""
+
+  for arg in "$@"; do
+    quoted_arg="$(printf '%q' "$arg")"
+    if [ -z "$formatted" ]; then
+      formatted="$quoted_arg"
+    else
+      formatted="$formatted $quoted_arg"
+    fi
+  done
+
+  printf '%s' "$formatted"
+}
+
+# Append a captured stdout or stderr file to the install log.
+# This intentionally writes only to LOG_ARRAY so terminal output stays concise.
+logCommandOutputFile() {
+  local label="$1"
+  local file_path="$2"
+  local line=""
+
+  if [ -s "$file_path" ]; then
+    logEntry "    $label:"
+    while IFS= read -r line || [ -n "$line" ]; do
+      logEntry "      $line"
+    done < "$file_path"
+  else
+    logEntry "    $label: <empty>"
+  fi
+}
+
+# Add detailed captured command failure diagnostics to LOG_ARRAY.
+# Call this after the user-facing fail/warn line has already been recorded.
+logCommandFailureDetails() {
+  local command_text="$1"
+  local status="$2"
+  local stdout_file="$3"
+  local stderr_file="$4"
+
+  logEntry "    Command: $command_text"
+  logEntry "    Exit code: $status"
+  logCommandOutputFile "stdout" "$stdout_file"
+  logCommandOutputFile "stderr" "$stderr_file"
+}
+
+# Add failure diagnostics for commands that must keep direct terminal access.
+# Use for commands that may prompt or manage their own terminal UI.
+logInteractiveCommandFailureDetails() {
+  local command_text="$1"
+  local status="$2"
+
+  logEntry "    Command: $command_text"
+  logEntry "    Exit code: $status"
+  logEntry "    stdout/stderr: not captured because command ran interactively"
+}
+
+# Run a command while capturing stdout into the caller-provided file and stderr
+# into a temporary file. On failure, terminal output is a short failure message
+# and the generated log receives command, exit code, stdout, and stderr.
+#
+# Usage:
+#   output_file="$(mktemp)"
+#   runCommandCapture "Find tool path" "$output_file" asdf where postgres
+runCommandCapture() {
+  local description="$1"
+  local stdout_file="$2"
+  shift 2
+  local stderr_file=""
+  local command_text=""
+  local status=0
+
+  if [ "$#" -eq 0 ]; then
+    fail "$description failed: no command provided"
+    return 1
+  fi
+
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/macsetup-command-stderr.XXXXXX")" || {
+    fail "$description failed: could not create stderr capture file"
+    return 1
+  }
+  command_text="$(formatCommandForLog "$@")"
+
+  "$@" > "$stdout_file" 2> "$stderr_file"
+  status="$?"
+
+  if [ "$status" -ne 0 ]; then
+    fail "$description failed"
+    logCommandFailureDetails "$command_text" "$status" "$stdout_file" "$stderr_file"
+    rm -f "$stderr_file"
+    return "$status"
+  fi
+
+  rm -f "$stderr_file"
+  return 0
+}
+
+# Run a command and assign its captured stdout to a named variable.
+# Use this instead of command substitution when the command can fail and the log
+# should include command, exit code, stdout, and stderr details.
+#
+# Usage:
+#   runCommandOutputVariable brewPrefix "Find Homebrew prefix" brew --prefix
+runCommandOutputVariable() {
+  local variable_name="$1"
+  local description="$2"
+  shift 2
+  local stdout_file=""
+  local output_value=""
+  local status=0
+
+  stdout_file="$(mktemp "${TMPDIR:-/tmp}/macsetup-command-stdout.XXXXXX")" || {
+    fail "$description failed: could not create stdout capture file"
+    return 1
+  }
+
+  if runCommandCapture "$description" "$stdout_file" "$@"; then
+    output_value="$(< "$stdout_file")"
+    printf -v "$variable_name" '%s' "$output_value"
+  else
+    status="$?"
+    rm -f "$stdout_file"
+    return "$status"
+  fi
+
+  rm -f "$stdout_file"
+  return 0
+}
+
+# Run an exploratory command and assign stdout to a named variable when it
+# succeeds. Use this for probing candidate paths where failure should not print
+# to the terminal or count toward FAILURES_ARRAY because a later probe may
+# succeed. Failed probes still write command, exit code, stdout, and stderr to
+# the generated log.
+#
+# Usage:
+#   runProbeCommandOutputVariable brewShellenv "Probe brew shellenv" "$brewPath" shellenv
+runProbeCommandOutputVariable() {
+  local variable_name="$1"
+  local description="$2"
+  shift 2
+  local stdout_file=""
+  local stderr_file=""
+  local command_text=""
+  local output_value=""
+  local status=0
+
+  if [ "$#" -eq 0 ]; then
+    warn "$description skipped: no command provided"
+    return 1
+  fi
+
+  stdout_file="$(mktemp "${TMPDIR:-/tmp}/macsetup-command-stdout.XXXXXX")" || {
+    warn "$description skipped: could not create stdout capture file"
+    return 1
+  }
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/macsetup-command-stderr.XXXXXX")" || {
+    rm -f "$stdout_file"
+    warn "$description skipped: could not create stderr capture file"
+    return 1
+  }
+  command_text="$(formatCommandForLog "$@")"
+
+  "$@" > "$stdout_file" 2> "$stderr_file"
+  status="$?"
+
+  if [ "$status" -eq 0 ]; then
+    output_value="$(< "$stdout_file")"
+    printf -v "$variable_name" '%s' "$output_value"
+  else
+    logEntry "    Probe failed: $description"
+    logCommandFailureDetails "$command_text" "$status" "$stdout_file" "$stderr_file"
+  fi
+
+  rm -f "$stdout_file" "$stderr_file"
+  return "$status"
+}
+
+# Run a non-interactive command whose output is only useful on failure.
+# Use for installs, copies, Git operations, and other shell-outs where normal
+# stdout/stderr would add noise to the installer UI.
+#
+# Usage:
+#   runCommand "Copy vimrc" cp "$source" "$HOME/.vimrc"
+runCommand() {
+  local description="$1"
+  shift
+  local stdout_file=""
+  local status=0
+
+  stdout_file="$(mktemp "${TMPDIR:-/tmp}/macsetup-command-stdout.XXXXXX")" || {
+    fail "$description failed: could not create stdout capture file"
+    return 1
+  }
+
+  runCommandCapture "$description" "$stdout_file" "$@"
+  status="$?"
+  rm -f "$stdout_file"
+
+  return "$status"
+}
+
+# Run a command directly attached to the terminal.
+# Use for commands that may prompt, need stdin, or own their terminal output.
+# Failure logs include command and exit code, but stdout/stderr are not captured.
+#
+# Usage:
+#   runInteractiveCommand "Run Homebrew installer" /bin/bash "$installer"
+runInteractiveCommand() {
+  local description="$1"
+  shift
+  local command_text=""
+  local status=0
+
+  if [ "$#" -eq 0 ]; then
+    fail "$description failed: no command provided"
+    return 1
+  fi
+
+  command_text="$(formatCommandForLog "$@")"
+  "$@"
+  status="$?"
+
+  if [ "$status" -ne 0 ]; then
+    fail "$description failed"
+    logInteractiveCommandFailureDetails "$command_text" "$status"
+    return "$status"
+  fi
+
+  return 0
+}
+
+# Run a best-effort command that should not count as an install failure.
+# Use for cleanup or advisory checks. Failures are warnings, and captured
+# stdout/stderr still go to the generated log for debugging.
+#
+# Usage:
+#   runOptionalCommand "Run brew doctor" brew doctor || true
+runOptionalCommand() {
+  local description="$1"
+  shift
+  local stdout_file=""
+  local stderr_file=""
+  local command_text=""
+  local status=0
+
+  if [ "$#" -eq 0 ]; then
+    warn "$description skipped: no command provided"
+    return 1
+  fi
+
+  stdout_file="$(mktemp "${TMPDIR:-/tmp}/macsetup-command-stdout.XXXXXX")" || {
+    warn "$description skipped: could not create stdout capture file"
+    return 1
+  }
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/macsetup-command-stderr.XXXXXX")" || {
+    rm -f "$stdout_file"
+    warn "$description skipped: could not create stderr capture file"
+    return 1
+  }
+  command_text="$(formatCommandForLog "$@")"
+
+  "$@" > "$stdout_file" 2> "$stderr_file"
+  status="$?"
+
+  if [ "$status" -ne 0 ]; then
+    warn "$description failed"
+    logCommandFailureDetails "$command_text" "$status" "$stdout_file" "$stderr_file"
+  fi
+
+  rm -f "$stdout_file" "$stderr_file"
+  return "$status"
+}
+
 warn() {
   local msg=""
 

--- a/sections/change_default_shell.sh
+++ b/sections/change_default_shell.sh
@@ -26,7 +26,7 @@ changeDefaultShell() {
     chooseOption "Choose Default Shell:" "${options[@]}"
     case "$MACSETUP_UI_CHOICE" in
       "Bash")
-        chsh -s "$(which bash)"
+        runInteractiveCommand "Change default shell to bash" chsh -s "$(which bash)" || return 1
         if [ "$(currShell)" == "$(which bash)" ]; then
           success "Default shell has been updated to bash"
         else
@@ -34,7 +34,7 @@ changeDefaultShell() {
         fi
         ;;
       "Zsh")
-        chsh -s "$(which zsh)"
+        runInteractiveCommand "Change default shell to zsh" chsh -s "$(which zsh)" || return 1
         if [ "$(currShell)" == "$(which zsh)" ]; then
           success "Default shell has been updated to zsh"
         else

--- a/sections/install_applications.sh
+++ b/sections/install_applications.sh
@@ -9,6 +9,8 @@ installApplications() {
   if isMacOs; then
     # Can only install brew apps if brew is installed
     if cmdExists brew; then
+      # Entry format: "application bundle name|Homebrew cask name|configure function".
+      # Leave the configure function field empty when no post-install step is needed.
       local applications=(
         "Caffeine.app|caffeine|"
         "Sip.app|sip|"
@@ -31,7 +33,7 @@ installApplications() {
 
       # Cleanup downloads
       info "Cleaning up application .zip and .dmg files"
-      brew cleanup
+      runOptionalCommand "Clean up Homebrew downloads" brew cleanup || true
     else
       fail "Failed to install Applications via Homebrew Cask. Homebrew is not installed."
     fi

--- a/sections/install_homebrew_packages.sh
+++ b/sections/install_homebrew_packages.sh
@@ -8,6 +8,8 @@ function runSection {
 installHomebrewPackages() {
   # Can only install brew packages if brew is installed
   if cmdExists brew; then
+    # Entry format: "display name|formula|assertion command|configure function|tap".
+    # Leave optional fields empty, preserving delimiters for later fields.
     local packages=(
       "openssl|openssl|openssl|configureOpenSSL|"
       "icu4c|icu4c|icuinfo|configureICU4C|"

--- a/sections/install_node.sh
+++ b/sections/install_node.sh
@@ -6,18 +6,5 @@ function runSection {
 }
 
 installNode() {
-  if cmdExists asdf; then
-    assertFileExists ~/.tool-versions "Found ~/.tool-versions file" "~/.tool-versions not found, cannot install Node via \`asdf\`."
-
-    info "Adding Node Plugin..."
-    asdf plugin-add nodejs
-
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      info "Installing Node from ~/.tool-versions: "$'\n'"---TOOLS---"$'\n'"$(cat ~/.tool-versions)"$'\n'"-----------"
-      asdf install nodejs
-      assertPackageInstallation node "node"
-    fi
-  else
-    fail "Failed to install node. \`asdf\` is required to install."
-  fi
+  installAsdfToolFromToolVersions "nodejs" "Node" "node"
 }

--- a/sections/install_postgres.sh
+++ b/sections/install_postgres.sh
@@ -6,38 +6,40 @@ function runSection {
 }
 
 installPostgres() {
-  if cmdExists asdf; then
-    assertFileExists ~/.tool-versions "Found ~/.tool-versions file" "~/.tool-versions not found, cannot install Postgres via \`asdf\`."
+  local postgres_path_file=""
+  local POSTGRES_PATH=""
 
-    info "Adding Postgres Plugin..."
-    asdf plugin-add postgres
+  installAsdfToolFromToolVersions "postgres" "Postgres" "postgres" || return 1
 
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      info "Installing Postgres from ~/.tool-versions: "$'\n'"---TOOLS---"$'\n'"$(cat ~/.tool-versions)"$'\n'"-----------"
-      asdf install postgres
-      assertPackageInstallation postgres "postgres"
+  if cmdExists postgres; then
+    postgres_path_file="$(mktemp "${TMPDIR:-/tmp}/macsetup-postgres-path.XXXXXX")" || {
+      fail "Failed to create temporary file for Postgres install path"
+      return 1
+    }
 
-      if cmdExists postgres; then
-        info "Adding postgres utility alias to ~/.utility_aliases"
-        POSTGRES_PATH=$(asdf where postgres)
-        # Preserve white space by changing the Internal Field Separator
-        IFS='%'
-        addLineToFiles "" ~/.utility_aliases
-        addLineToFiles "# Start Postgres" ~/.utility_aliases
-        addLineToFiles "startPostgres() {" ~/.utility_aliases
-        addLineToFiles "  $POSTGRES_PATH/bin/pg_ctl -D $POSTGRES_PATH/data start" ~/.utility_aliases
-        addLineToFiles "}" ~/.utility_aliases
-        # Reset the Internal Field Separator
-        unset IFS
-
-        if grep -q "# Start Postgres" ~/.utility_aliases; then
-          success "Utility alias 'startPostgres' has been set"
-        else
-          fail "Failed to set utility alias 'startPostgres'"
-        fi
-      fi
+    if ! runCommandCapture "Find Postgres asdf install path" "$postgres_path_file" asdf where postgres; then
+      rm -f "$postgres_path_file"
+      return 1
     fi
-  else
-    fail "Failed to install postgres. \`asdf\` is required to install."
+
+    IFS= read -r POSTGRES_PATH < "$postgres_path_file"
+    rm -f "$postgres_path_file"
+
+    info "Adding postgres utility alias to ~/.utility_aliases"
+    # Preserve white space by changing the Internal Field Separator
+    IFS='%'
+    addLineToFiles "" ~/.utility_aliases
+    addLineToFiles "# Start Postgres" ~/.utility_aliases
+    addLineToFiles "startPostgres() {" ~/.utility_aliases
+    addLineToFiles "  $POSTGRES_PATH/bin/pg_ctl -D $POSTGRES_PATH/data start" ~/.utility_aliases
+    addLineToFiles "}" ~/.utility_aliases
+    # Reset the Internal Field Separator
+    unset IFS
+
+    if grep -q "# Start Postgres" ~/.utility_aliases; then
+      success "Utility alias 'startPostgres' has been set"
+    else
+      fail "Failed to set utility alias 'startPostgres'"
+    fi
   fi
 }

--- a/sections/install_python.sh
+++ b/sections/install_python.sh
@@ -6,18 +6,5 @@ function runSection {
 }
 
 installPython() {
-  if cmdExists asdf; then
-    assertFileExists ~/.tool-versions "Found ~/.tool-versions file" "~/.tool-versions not found, cannot install Python via \`asdf\`."
-
-    info "Adding Python Plugin..."
-    asdf plugin-add python
-
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      info "Installing Python from ~/.tool-versions: "$'\n'"---TOOLS---"$'\n'"$(cat ~/.tool-versions)"$'\n'"-----------"
-      asdf install python
-      assertPackageInstallation python "python"
-    fi
-  else
-    fail "Failed to install python. \`asdf\` is required to install."
-  fi
+  installAsdfToolFromToolVersions "python" "Python" "python"
 }

--- a/sections/install_ruby.sh
+++ b/sections/install_ruby.sh
@@ -6,18 +6,5 @@ function runSection {
 }
 
 installRuby() {
-  if cmdExists asdf; then
-    assertFileExists ~/.tool-versions "Found ~/.tool-versions file" "~/.tool-versions not found, cannot install Ruby via \`asdf\`."
-
-    info "Adding Ruby Plugin..."
-    asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby.git
-
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-      info "Installing Ruby from ~/.tool-versions: "$'\n'"---TOOLS---"$'\n'"$(cat ~/.tool-versions)"$'\n'"-----------"
-      asdf install ruby
-      assertPackageInstallation ruby "ruby"
-    fi
-  else
-    fail "Failed to install ruby. \`asdf\` is required to install."
-  fi
+  installAsdfToolFromToolVersions "ruby" "Ruby" "ruby" "https://github.com/asdf-vm/asdf-ruby.git"
 }

--- a/sections/install_xcode_and_git.sh
+++ b/sections/install_xcode_and_git.sh
@@ -8,7 +8,7 @@ function runSection {
 installXcodeAndGit() {
   if isMacOs; then
     info "Installing Xcode Command Line Tools"
-    xcode-select --install
+    runOptionalCommand "Install Xcode Command Line Tools" xcode-select --install || true
     # Test to ensure successful install
     assertPackageInstallation gcc "Xcode CLT"
     assertPackageInstallation git "Git"

--- a/sections/setup_asdf.sh
+++ b/sections/setup_asdf.sh
@@ -6,12 +6,37 @@ function runSection {
 }
 
 setupAsdf() {
-  local currDir="$(scriptDirectory)";
-  git clone https://github.com/asdf-vm/asdf.git ~/.asdf
-  cd ~/.asdf
-  git checkout "$(git describe --abbrev=0 --tags)"
+  local currDir="$(scriptDirectory)"
+  local asdfDir="$HOME/.asdf"
+  local asdfVersion="${ASDF_VERSION:-v0.15.0}"
 
-  source $HOME/.asdf/asdf.sh
+  if [ -d "$asdfDir/.git" ]; then
+    info "asdf repository already exists at $asdfDir"
+    if git -C "$asdfDir" rev-parse -q --verify "$asdfVersion^{commit}" >/dev/null 2>&1; then
+      info "asdf release $asdfVersion is already available locally"
+    else
+      runCommand "Fetch asdf release tags" git -C "$asdfDir" fetch --tags --force || return 1
+    fi
+  else
+    if [ -e "$asdfDir" ]; then
+      fail "Cannot install asdf because $asdfDir exists but is not a git repository"
+      return 1
+    fi
+
+    runCommand "Clone asdf version manager $asdfVersion" git clone --branch "$asdfVersion" https://github.com/asdf-vm/asdf.git "$asdfDir" || return 1
+  fi
+
+  # MacSetup configures the legacy shell-based asdf loader. asdf v0.16+ changed
+  # its install layout, so keep the git install pinned to the matching release.
+  runCommand "Checkout asdf release $asdfVersion" git -C "$asdfDir" checkout "$asdfVersion" || return 1
+
+  if [ ! -f "$asdfDir/asdf.sh" ]; then
+    fail "Failed to find asdf shell loader at $asdfDir/asdf.sh"
+    return 1
+  fi
+
+  # shellcheck source=/dev/null
+  source "$asdfDir/asdf.sh"
   assertPackageInstallation asdf "asdf"
   cd "$currDir"
 
@@ -22,13 +47,10 @@ setupAsdf() {
   addLineToFiles '. $HOME/.asdf/completions/asdf.bash' ~/.bash_profile ~/.bashrc
   success 'Added asdf configuration to shell startup files'
 
-  source ~/.bash_profile
-  source ~/.zprofile
-
   info "Backing up ~/.tool-versions"
   backupFile ~/.tool-versions tool-versions
 
-  cp "$MACSETUP_CONFIG_DIR"/asdf/tool-versions ~/.tool-versions
+  runCommand "Copy asdf tool versions" cp "$MACSETUP_CONFIG_DIR"/asdf/tool-versions ~/.tool-versions || return 1
   assertFileExists ~/.tool-versions "~/.tool-versions set" "Failed to set ~/.tool-versions"
 
   assertPackageInstallation asdf "asdf"

--- a/sections/setup_dot_files.sh
+++ b/sections/setup_dot_files.sh
@@ -17,7 +17,7 @@ setupDotFiles() {
 
   # Set Dot Files
   for dotFileName in "${MACSETUP_MANAGED_TOP_LEVEL_DOTFILES[@]}"; do
-    cp "$MACSETUP_CONFIG_DIR"/dotfiles/mac/"$dotFileName".sh ~/."$dotFileName"
+    runCommand "Copy ~/.$dotFileName" cp "$MACSETUP_CONFIG_DIR"/dotfiles/mac/"$dotFileName".sh ~/."$dotFileName" || continue
     assertFileExists ~/."$dotFileName" "~/.$dotFileName set" "Failed to set ~/.$dotFileName"
   done
 }

--- a/sections/setup_fonts.sh
+++ b/sections/setup_fonts.sh
@@ -8,15 +8,15 @@ function runSection {
 setupFonts() {
   if isMacOs; then
     info "Opening Inconsolata-g.otf font"
-    open "$MACSETUP_ASSETS_DIR/fonts/Inconsolata-g.otf"
+    runCommand "Open Inconsolata-g.otf font" open "$MACSETUP_ASSETS_DIR/fonts/Inconsolata-g.otf" || return 1
     manualAction "Press Install Font Button for Inconsolata-g.otf"
 
     info "Opening Powerline Inconsolata-g font"
-    open "$MACSETUP_ASSETS_DIR/fonts/Inconsolata-g for Powerline.otf"
+    runCommand "Open Powerline Inconsolata-g font" open "$MACSETUP_ASSETS_DIR/fonts/Inconsolata-g for Powerline.otf" || return 1
     manualAction "Press Install Font Button for Inconsolata-g for Powerline.otf"
 
     info "Opening Inconsolata Nerd Font Icons.otf"
-    open "$MACSETUP_ASSETS_DIR/fonts/Inconsolata Nerd Font Icons.otf"
+    runCommand "Open Inconsolata Nerd Font Icons.otf" open "$MACSETUP_ASSETS_DIR/fonts/Inconsolata Nerd Font Icons.otf" || return 1
     manualAction "Press Install Font Button for Inconsolata Nerd Font Icons.otf"
   else
     warn "This is a MacOS specific step, skipping due to invalid OS..."

--- a/sections/setup_git.sh
+++ b/sections/setup_git.sh
@@ -7,12 +7,14 @@ function runSection {
 
 setupGit() {
   if cmdExists git; then
+    local sshAgentEnv=""
+
     info "Configuring git"
     # Backup files
     backupFile ~/.gitconfig gitconfig
 
     # Set .gitconfig
-    cp "$MACSETUP_CONFIG_DIR/git/gitconfig" ~/.gitconfig
+    runCommand "Copy gitconfig" cp "$MACSETUP_CONFIG_DIR/git/gitconfig" ~/.gitconfig || return 1
     assertFileExists ~/.gitconfig "~/.gitconfig set" "Failed to set ~/.gitconfig"
 
     # Backup global .gitignore
@@ -21,20 +23,20 @@ setupGit() {
 
     # Set Global Gitignore
     info "Setting global .gitignore"
-    cp "$MACSETUP_CONFIG_DIR"/dotfiles/mac/gitignore.sh ~/.gitignore
+    runCommand "Copy global gitignore" cp "$MACSETUP_CONFIG_DIR"/dotfiles/mac/gitignore.sh ~/.gitignore || return 1
     assertFileExists ~/.gitignore "~/.gitignore set" "Failed to set ~/.gitignore"
 
     # Assign global gitignore in global gitconfig
-    git config --global core.excludesfile ~/.gitignore
+    runCommand "Configure global git excludesfile" git config --global core.excludesfile ~/.gitignore || return 1
 
     # Set Github Username and email
     prompt "What is your Github User Name (i.e. \"First Last\")?"
-    git config --global user.name "$REPLY"
+    runCommand "Configure global git username" git config --global user.name "$REPLY" || return 1
     success "Username set to $REPLY"
     prompt "What is your Github Email (i.e. \"me@mail.com\")?"
     GIT_EMAIL="$REPLY"
     success "Email set to $GIT_EMAIL"
-    git config --global user.email "$GIT_EMAIL"
+    runCommand "Configure global git email" git config --global user.email "$GIT_EMAIL" || return 1
 
     promptYesNo "Create an SSH Key For Email: $GIT_EMAIL?"
     if [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -43,8 +45,8 @@ setupGit() {
         info "Found $SSH_CONFIG File"
       else
         info "Creating $SSH_CONFIG File..."
-        mkdir -p ~/.ssh
-        touch "$SSH_CONFIG"
+        runCommand "Create SSH config directory" mkdir -p ~/.ssh || return 1
+        runCommand "Create SSH config file" touch "$SSH_CONFIG" || return 1
       fi
 
       DEAULT_KEY_NAME="git_key_ecdsa"
@@ -56,11 +58,12 @@ setupGit() {
       fi
       KEY_PATH=~/.ssh/$KEY_NAME
 
-      ssh-keygen -f "$KEY_PATH" -t ed25519 -C "$GIT_EMAIL"
+      runInteractiveCommand "Create SSH key $KEY_PATH" ssh-keygen -f "$KEY_PATH" -t ed25519 -C "$GIT_EMAIL" || return 1
       assertFileExists "$KEY_PATH" "Successfully created SSH Key: $KEY_PATH" "Failed to create SSH Key: $KEY_PATH"
 
       info "Starting ssh-agent in background"
-      eval "$(ssh-agent -s)"
+      runCommandOutputVariable sshAgentEnv "Start ssh-agent" ssh-agent -s || return 1
+      eval "$sshAgentEnv"
       echo
 
       # Preserve white space by changing the Internal Field Separator

--- a/sections/setup_homebrew.sh
+++ b/sections/setup_homebrew.sh
@@ -6,16 +6,34 @@ function runSection {
 }
 
 setupHomebrew() {
+  local brewInstaller=""
+  local brewShellenv=""
+  local brewPrefix=""
+  local prefix=""
+  local BREW_PATH=""
+
   info "Installing Homebrew package manager"
   # Install Brew if it isn't already
   if cmdExists brew; then
     info "Homebrew is already installed"
   else
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    brewInstaller="$(mktemp "${TMPDIR:-/tmp}/macsetup-homebrew-install.XXXXXX")" || {
+      fail "Failed to create temporary file for Homebrew installer"
+      return 1
+    }
+    runCommand "Download Homebrew installer" curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh -o "$brewInstaller" || {
+      rm -f "$brewInstaller"
+      return 1
+    }
+    runInteractiveCommand "Run Homebrew installer" /bin/bash "$brewInstaller" || {
+      rm -f "$brewInstaller"
+      return 1
+    }
+    rm -f "$brewInstaller"
   fi
 
   # Attempt to find brew prefix automatically
-  prefixes=(
+  local prefixes=(
     "/usr/local"
     "/opt/homebrew"
     "/home/linuxbrew/.linuxbrew"
@@ -24,7 +42,9 @@ setupHomebrew() {
     BREW_PATH=$prefix/bin/brew
     if [ -f "$BREW_PATH" ]; then
       info "Loading brew into current context..."
-      eval "$("$BREW_PATH" shellenv)"
+      if runProbeCommandOutputVariable brewShellenv "Probe Homebrew shellenv from $BREW_PATH" "$BREW_PATH" shellenv; then
+        eval "$brewShellenv"
+      fi
     fi
   done
 
@@ -49,15 +69,17 @@ setupHomebrew() {
 
   if cmdExists brew; then
     info "Updating homebrew"
-    brew update
+    runCommand "Update Homebrew" brew update || return 1
     info "Making homebrew healthy with brew doctor"
-    brew doctor
+    runOptionalCommand "Run brew doctor" brew doctor || true
 
     info 'Adding Homebrew to $PATH in .bash_profile and .zprofile'
+    runCommandOutputVariable brewPrefix "Find Homebrew prefix" brew --prefix || return 1
     addLineToFiles "" ~/.bash_profile ~/.zprofile
     addLineToFiles "# Homebrew Package Manager" ~/.bash_profile ~/.zprofile
-    addLineToFiles "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" ~/.bash_profile ~/.zprofile
-    eval "$($(brew --prefix)/bin/brew shellenv)"
+    addLineToFiles "eval \"\$($brewPrefix/bin/brew shellenv)\"" ~/.bash_profile ~/.zprofile
+    runCommandOutputVariable brewShellenv "Load Homebrew shellenv" "$brewPrefix/bin/brew" shellenv || return 1
+    eval "$brewShellenv"
     success 'Added Homebrew to $PATH in ~/.bash_profile and ~/.zprofile'
   else
     fail "Failed to update Homebrew because it is not installed"

--- a/sections/setup_screensavers.sh
+++ b/sections/setup_screensavers.sh
@@ -8,7 +8,7 @@ function runSection {
 setupScreensavers() {
   if isMacOs; then
     info "Opening Aerial.saver"
-    open "$MACSETUP_ASSETS_DIR/screensavers/Aerial.saver"
+    runCommand "Open Aerial.saver" open "$MACSETUP_ASSETS_DIR/screensavers/Aerial.saver" || return 1
     manualAction "Follow MacOSX prompts to install Aerial.saver"
   else
     warn "This is a MacOS specific step, skipping due to invalid OS..."

--- a/sections/setup_splash_screen.sh
+++ b/sections/setup_splash_screen.sh
@@ -20,7 +20,7 @@ setupSplashScreen() {
         COMMAND_CHOICE="charizard"
         ;;
       "Initials")
-        cp "$MACSETUP_ASSETS_DIR/splash/mcc_logo.png" ~/mcc_logo.png
+        runCommand "Copy splash screen logo" cp "$MACSETUP_ASSETS_DIR/splash/mcc_logo.png" ~/mcc_logo.png || return 1
         assertFileExists ~/mcc_logo.png "Copied over mcc_logo.png asset" "Failed to copy over mcc_logo.png asset"
         COMMAND_CHOICE="mcc"
         ;;
@@ -37,7 +37,7 @@ setupSplashScreen() {
       info "Cancelling splash screen setup..."
     else
       info "Setting splash screen to use command '$COMMAND_CHOICE'"
-      sed -i -e "s/local SPLASH_COMMAND=.*/local SPLASH_COMMAND=$COMMAND_CHOICE/" ~/.bashrc
+      runCommand "Update splash screen command" sed -i -e "s/local SPLASH_COMMAND=.*/local SPLASH_COMMAND=$COMMAND_CHOICE/" ~/.bashrc || return 1
 
       if grep -q "local SPLASH_COMMAND=$COMMAND_CHOICE" ~/.bashrc; then
         success "Splash screen set to use command '$COMMAND_CHOICE'"

--- a/sections/setup_vim.sh
+++ b/sections/setup_vim.sh
@@ -13,12 +13,12 @@ setupVim() {
 
   # Set .vim folder
   info "Setting up .vim folder"
-  rm -rf ~/.vim
-  cp -r "$MACSETUP_ASSETS_DIR/vim" ~/.vim
+  runCommand "Remove existing ~/.vim directory" rm -rf ~/.vim || return 1
+  runCommand "Copy vim assets" cp -r "$MACSETUP_ASSETS_DIR/vim" ~/.vim || return 1
   assertDirectoryExists ~/.vim "~/.vim directory set" "Failed to set ~/.vim directory"
   assertFileExists ~/.vim/autoload/pathogen.vim "pathogen.vim set" "Failed to set pathogen.vim"
   assertFileExists ~/.vim/colors/atom_one_dark.vim "Atom One Dark colorscheme set" "Failed to set Atom One Dark colorscheme"
-  mkdir -p ~/.vim/bundle
+  runCommand "Create vim bundle directory" mkdir -p ~/.vim/bundle || return 1
 
   # Backup .vimrc
   info "Backing up .vimrc"
@@ -26,7 +26,7 @@ setupVim() {
 
   # Set .vimrc
   info "Setting up .vimrc"
-  cp "$MACSETUP_CONFIG_DIR"/dotfiles/mac/vimrc.sh ~/.vimrc
+  runCommand "Copy vimrc" cp "$MACSETUP_CONFIG_DIR"/dotfiles/mac/vimrc.sh ~/.vimrc || return 1
   assertFileExists ~/.vimrc "~/.vimrc set" "Failed to set ~/.vimrc"
 
   # Clone all vim plugins
@@ -52,17 +52,17 @@ setupVim() {
   for pluginUrl in "${vimPlugins[@]}"; do
     repoName=$(repoName "$pluginUrl")
     cloneToPath=~/".vim/bundle/$repoName"
-    rm -rf "$cloneToPath"
+    runCommand "Remove existing vim plugin $repoName" rm -rf "$cloneToPath" || continue
     if [ "$repoName" = "coc.nvim" ]; then
-      git clone --branch release "$pluginUrl" "$cloneToPath"
+      runCommand "Clone vim plugin $repoName" git clone --branch release "$pluginUrl" "$cloneToPath" || continue
     else
-      git clone "$pluginUrl" "$cloneToPath"
+      runCommand "Clone vim plugin $repoName" git clone "$pluginUrl" "$cloneToPath" || continue
     fi
     # Invoke installation script if exists (i.e. for fzf)
     installPath="$cloneToPath/install"
     if [ -f "$installPath" ]; then
       echo -e "\n\nInvoking installation for $repoName\n"
-      "$installPath"
+      runInteractiveCommand "Run vim plugin installer for $repoName" "$installPath" || continue
     fi
     assertDirectoryExists "$cloneToPath" "$repoName plugin added to $cloneToPath" "Failed to add plugin $repoName to $cloneToPath"
   done

--- a/sections/setup_wallpaper.sh
+++ b/sections/setup_wallpaper.sh
@@ -11,21 +11,21 @@ setupWallpaper() {
     chooseOption "Choose Wallpaper:" "${options[@]}"
     case "$MACSETUP_UI_CHOICE" in
       "Sushi Keyboard Key")
-        cp "$MACSETUP_ASSETS_DIR/wallpapers/sushi_key.png" ~/wallpaper.png
+        runCommand "Copy Sushi Keyboard Key wallpaper" cp "$MACSETUP_ASSETS_DIR/wallpapers/sushi_key.png" ~/wallpaper.png || return 1
         assertFileExists ~/wallpaper.png "Copied over wallpaper.png asset" "Failed to copy over wallpaper.png asset"
-        open ~/
+        runCommand "Open home directory for wallpaper setup" open ~/ || return 1
         manualAction "Right click wallpaper.png and select 'Set Desktop Picture'"
         ;;
       "Samurai Cat")
-        cp "$MACSETUP_ASSETS_DIR/wallpapers/samurai_cat.png" ~/wallpaper.png
+        runCommand "Copy Samurai Cat wallpaper" cp "$MACSETUP_ASSETS_DIR/wallpapers/samurai_cat.png" ~/wallpaper.png || return 1
         assertFileExists ~/wallpaper.png "Copied over wallpaper.png asset" "Failed to copy over wallpaper.png asset"
-        open ~/
+        runCommand "Open home directory for wallpaper setup" open ~/ || return 1
         manualAction "Right click wallpaper.png and select 'Set Desktop Picture'"
         ;;
       "Heroku")
-        cp "$MACSETUP_ASSETS_DIR/wallpapers/heroku.png" ~/wallpaper.png
+        runCommand "Copy Heroku wallpaper" cp "$MACSETUP_ASSETS_DIR/wallpapers/heroku.png" ~/wallpaper.png || return 1
         assertFileExists ~/wallpaper.png "Copied over wallpaper.png asset" "Failed to copy over wallpaper.png asset"
-        open ~/
+        runCommand "Open home directory for wallpaper setup" open ~/ || return 1
         manualAction "Right click wallpaper.png and select 'Set Desktop Picture'"
         ;;
       "Cancel")

--- a/sections/setup_zsh.sh
+++ b/sections/setup_zsh.sh
@@ -12,7 +12,7 @@ setupZsh() {
 
   # Set .oh-my-zsh folder
   info "Setting up .oh-my-zsh folder"
-  rm -rf ~/.oh-my-zsh
+  runCommand "Remove existing ~/.oh-my-zsh directory" rm -rf ~/.oh-my-zsh || return 1
 
   # Clone oh-my-zsh
   ZSH=${ZSH:-~/.oh-my-zsh}
@@ -20,15 +20,13 @@ setupZsh() {
   REMOTE=${REMOTE:-https://github.com/${REPO}.git}
   BRANCH=${BRANCH:-master}
 
-  git clone -c core.eol=lf -c core.autocrlf=false \
+  runCommand "Clone oh-my-zsh repo" git clone -c core.eol=lf -c core.autocrlf=false \
     -c fsck.zeroPaddedFilemode=ignore \
     -c fetch.fsck.zeroPaddedFilemode=ignore \
     -c receive.fsck.zeroPaddedFilemode=ignore \
     -c oh-my-zsh.remote=origin \
     -c oh-my-zsh.branch="$BRANCH" \
-    --depth=1 --branch "$BRANCH" "$REMOTE" "$ZSH" || {
-    fail "Failed to clone oh-my-zsh repo"
-  }
+    --depth=1 --branch "$BRANCH" "$REMOTE" "$ZSH" || return 1
 
   assertDirectoryExists ~/.oh-my-zsh "~/.oh-my-zsh directory set" "Failed to set ~/.oh-my-zsh directory"
 
@@ -41,13 +39,13 @@ setupZsh() {
   for pluginUrl in "${zshPlugins[@]}"; do
     repoName=$(repoName "$pluginUrl")
     cloneToPath=~/".oh-my-zsh/custom/plugins/$repoName"
-    rm -rf "$cloneToPath"
-    git clone "$pluginUrl" "$cloneToPath"
+    runCommand "Remove existing oh-my-zsh plugin $repoName" rm -rf "$cloneToPath" || continue
+    runCommand "Clone oh-my-zsh plugin $repoName" git clone "$pluginUrl" "$cloneToPath" || continue
     # Invoke installation script if exists
     installPath="$cloneToPath/install"
     if [ -f "$installPath" ]; then
       echo -e "\n\nInvoking installation for $repoName\n"
-      "$installPath"
+      runInteractiveCommand "Run oh-my-zsh plugin installer for $repoName" "$installPath" || continue
     fi
     assertDirectoryExists "$cloneToPath" "$repoName plugin added to $cloneToPath" "Failed to add plugin $repoName to $cloneToPath"
   done


### PR DESCRIPTION
## Summary
- Add reusable command wrappers for captured, output-variable, optional, and interactive commands.
- Route installation-wide shell-outs through those wrappers: Homebrew formula/cask installs, app configuration, dotfile/file edits, Vim/Zsh plugin clones, wallpaper/font/screensaver opens, Git config, shell changes, Homebrew setup, and asdf-backed installs.
- Keep terminal failures concise while writing command, exit code, stdout, and stderr into ~/.mac_setup/log for captured command failures.
- Preserve interactivity for commands that may prompt, logging command and exit status if they fail instead of hiding prompts.
- Pin the git-based asdf install to v0.15.0, matching the repo's legacy asdf.sh shell startup wiring.
- Add coverage for command output capture, Homebrew failure logging, and fake-asdf installer rerun behavior.

## Validation
- bash -n install.sh lib/macsetup/logging.sh lib/macsetup/installers.sh lib/macsetup/backup.sh lib/macsetup/appConfigUtil.sh sections/*.sh ci/test_installers.sh ci/test_command_logging.sh
- git diff --check
- bash ./ci/test_command_logging.sh
- bash ./ci/test_installers.sh
- bash ./ci/test_file_edits.sh
- bash ./ci/test_configure_bat.sh
- bash ./ci/checks.sh
- bash ./ci/docker_install_smoke.sh vim-modern node:22-bookworm
- Docker sandbox: forced bad ASDF_VERSION keeps command details out of terminal output and writes command, exit code, stdout, stderr, and Git fatal message into /home/sandbox_user/.mac_setup/log
- Docker sandbox: top-level dotfiles section succeeds with no command-detail failures