### PR TITLE
Fix latest asdf install

### DIFF
--- a/ci/checks.sh
+++ b/ci/checks.sh
@@ -21,6 +21,15 @@ printf '3\n' | ./start.sh
 echo "Checking UI prompt behavior..."
 bash ./ci/test_ui.sh
 
+echo "Checking PATH helper behavior..."
+bash ./ci/test_path_helpers.sh
+
+echo "Checking terminal compatibility behavior..."
+bash ./ci/test_terminal_compat.sh
+
+echo "Checking platform-specific Git config behavior..."
+bash ./ci/test_setup_git_platform.sh
+
 echo "Checking install.sh skipped-section path with isolated HOME..."
 tmp_home="$(mktemp -d)"
 cleanup() {

--- a/ci/test_path_helpers.sh
+++ b/ci/test_path_helpers.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$repo_root"
+
+if [ -z "${TERM:-}" ] || [ "$TERM" = "dumb" ]; then
+  export TERM="xterm"
+fi
+
+source ./lib/macsetup/constants.sh
+source ./lib/macsetup/helperFunctions.sh
+
+die() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+assertEquals() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+
+  if [ "$actual" != "$expected" ]; then
+    printf 'FAIL: %s\nExpected: %s\nActual:   %s\n' "$message" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assertPathCount() {
+  local path_entry="$1"
+  local expected_count="$2"
+  local message="$3"
+
+  assertEquals "$expected_count" "$(countPathEntry "$path_entry")" "$message"
+}
+
+countPathEntry() {
+  local path_entry="$1"
+  local old_ifs="$IFS"
+  local part=""
+  local count=0
+
+  IFS=:
+  for part in $PATH; do
+    if [ "$part" = "$path_entry" ]; then
+      count=$((count + 1))
+    fi
+  done
+  IFS="$old_ifs"
+
+  printf "%s\n" "$count"
+}
+
+assertPathContains() {
+  local path_entry="$1"
+  local message="$2"
+
+  if ! pathContainsEntry "$path_entry"; then
+    die "$message"
+  fi
+}
+
+assertPathMissing() {
+  local path_entry="$1"
+  local message="$2"
+
+  if pathContainsEntry "$path_entry"; then
+    die "$message"
+  fi
+}
+
+echo "Checking PATH entry detection..."
+PATH="/opt/macsetup/bin:/usr/bin:/bin:/Applications/Test App/bin"
+assertPathContains "/opt/macsetup/bin" "expected first PATH entry to be detected"
+assertPathContains "/usr/bin" "expected middle PATH entry to be detected"
+assertPathContains "/Applications/Test App/bin" "expected PATH entry with spaces to be detected"
+assertPathMissing "/opt/macsetup" "partial PATH entry should not match"
+assertPathMissing "/bin-extra" "suffix-like PATH entry should not match"
+assertPathMissing "" "empty PATH entry should not be treated as present"
+
+old_ifs="$IFS"
+pathContainsEntry "/usr/bin"
+assertEquals "$old_ifs" "$IFS" "pathContainsEntry should restore IFS"
+
+echo "Checking idempotent runtime PATH prepends..."
+PATH="/usr/bin:/bin"
+prependPathEntry "/opt/macsetup/bin"
+prependPathEntry "/opt/macsetup/bin"
+assertEquals "/opt/macsetup/bin:/usr/bin:/bin" "$PATH" "prependPathEntry should add a missing entry once"
+assertPathCount "/opt/macsetup/bin" 1 "prepended entry should appear exactly once"
+
+PATH="/usr/bin:/opt/macsetup/bin:/bin"
+prependPathEntry "/opt/macsetup/bin"
+assertEquals "/usr/bin:/opt/macsetup/bin:/bin" "$PATH" "prependPathEntry should not duplicate an existing middle entry"
+assertPathCount "/opt/macsetup/bin" 1 "existing middle entry should remain single"
+
+PATH=""
+prependPathEntry "/opt/empty-path/bin"
+assertEquals "/opt/empty-path/bin" "$PATH" "prependPathEntry should handle an empty PATH"
+
+PATH="/usr/bin:/bin"
+prependPathEntry ""
+assertEquals "/usr/bin:/bin" "$PATH" "prependPathEntry should ignore an empty input"
+
+PATH="/usr/bin:/bin"
+prependPathEntries "/opt/first/bin" "/opt/second bin" "/opt/third/bin"
+assertEquals "/opt/first/bin:/opt/second bin:/opt/third/bin:/usr/bin:/bin" "$PATH" "prependPathEntries should preserve caller order"
+prependPathEntries "/opt/first/bin" "/opt/second bin" "/opt/third/bin"
+assertEquals "/opt/first/bin:/opt/second bin:/opt/third/bin:/usr/bin:/bin" "$PATH" "prependPathEntries should be idempotent"
+assertPathCount "/opt/second bin" 1 "multi-prepended path with spaces should appear once"
+
+PATH="/usr/bin:/bin"
+prependPathEntries
+assertEquals "/usr/bin:/bin" "$PATH" "prependPathEntries with no args should leave PATH unchanged"
+
+echo "Checking idempotent runtime PATH appends..."
+PATH="/usr/bin:/bin"
+appendPathEntry "/Applications/Test App/bin"
+appendPathEntry "/Applications/Test App/bin"
+assertEquals "/usr/bin:/bin:/Applications/Test App/bin" "$PATH" "appendPathEntry should add a missing entry once"
+assertPathCount "/Applications/Test App/bin" 1 "appended entry should appear exactly once"
+
+PATH="/Applications/Test App/bin:/usr/bin:/bin"
+appendPathEntry "/Applications/Test App/bin"
+assertEquals "/Applications/Test App/bin:/usr/bin:/bin" "$PATH" "appendPathEntry should not duplicate an existing first entry"
+
+PATH=""
+appendPathEntry "/opt/empty-path/bin"
+assertEquals "/opt/empty-path/bin" "$PATH" "appendPathEntry should handle an empty PATH"
+
+PATH="/usr/bin:/bin"
+appendPathEntry ""
+assertEquals "/usr/bin:/bin" "$PATH" "appendPathEntry should ignore an empty input"
+
+echo "Checking generated shell PATH guards..."
+tmp_shell="$(mktemp)"
+cleanup() {
+  rm -f "$tmp_shell"
+}
+trap cleanup EXIT
+
+{
+  pathPrependShellLine '$HOME/.asdf/bin'
+  pathPrependShellLine '$HOME/.asdf/shims'
+  pathAppendShellLine '/Applications/Test App/bin'
+} > "$tmp_shell"
+
+PATH="/usr/bin:/bin"
+# shellcheck source=/dev/null
+source "$tmp_shell"
+# shellcheck source=/dev/null
+source "$tmp_shell"
+
+assertEquals "$HOME/.asdf/shims:$HOME/.asdf/bin:/usr/bin:/bin:/Applications/Test App/bin" "$PATH" "generated shell guards should preserve order and append position"
+assertPathCount "$HOME/.asdf/bin" 1 "generated prepend guard should add asdf bin once"
+assertPathCount "$HOME/.asdf/shims" 1 "generated prepend guard should add asdf shims once"
+assertPathCount "/Applications/Test App/bin" 1 "generated append guard should add VSCode-like path once"
+
+echo "Checking generated shell guards use exact PATH matches..."
+{
+  pathPrependShellLine '/opt/tool/bin'
+  pathAppendShellLine '/Applications/Tool.app/bin'
+} > "$tmp_shell"
+
+PATH="/opt/tool/bin-extra:/usr/bin:/Applications/Tool.app/bin-extra"
+# shellcheck source=/dev/null
+source "$tmp_shell"
+
+assertPathCount "/opt/tool/bin" 1 "prepend shell guard should not mistake a prefix match for an existing entry"
+assertPathCount "/opt/tool/bin-extra" 1 "prepend shell guard should preserve neighboring prefix-like entry"
+assertPathCount "/Applications/Tool.app/bin" 1 "append shell guard should not mistake a prefix match for an existing entry"
+assertPathCount "/Applications/Tool.app/bin-extra" 1 "append shell guard should preserve neighboring prefix-like entry"
+
+echo "Checking generated shell guards are safe across multiple startup files..."
+zprofile="$(mktemp)"
+zshrc="$(mktemp)"
+trap 'rm -f "$tmp_shell" "$zprofile" "$zshrc"' EXIT
+{
+  pathPrependShellLine '$HOME/.asdf/bin'
+  pathPrependShellLine '$HOME/.asdf/shims'
+} > "$zprofile"
+{
+  pathPrependShellLine '$HOME/.asdf/bin'
+  pathPrependShellLine '$HOME/.asdf/shims'
+} > "$zshrc"
+
+PATH="/usr/bin:/bin"
+# shellcheck source=/dev/null
+source "$zprofile"
+# shellcheck source=/dev/null
+source "$zshrc"
+
+assertPathCount "$HOME/.asdf/bin" 1 "sourcing zprofile and zshrc should not duplicate asdf bin"
+assertPathCount "$HOME/.asdf/shims" 1 "sourcing zprofile and zshrc should not duplicate asdf shims"

--- a/ci/test_setup_git_platform.sh
+++ b/ci/test_setup_git_platform.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$repo_root"
+
+if [ -z "${TERM:-}" ] || [ "$TERM" = "dumb" ]; then
+  export TERM="xterm"
+fi
+
+tmp_root="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_root"
+}
+trap cleanup EXIT
+
+writeFakeCommands() {
+  local fake_bin="$1"
+  local uname_value="$2"
+
+  mkdir -p "$fake_bin"
+
+  cat > "$fake_bin/uname" <<UNAME
+#!/bin/sh
+if [ "\${1:-}" = "-s" ]; then
+  printf '%s\n' "$uname_value"
+else
+  printf '%s\n' "$uname_value"
+fi
+UNAME
+
+  cat > "$fake_bin/git" <<'GIT'
+#!/bin/sh
+exit 0
+GIT
+
+  cat > "$fake_bin/ssh-keygen" <<'SSH_KEYGEN'
+#!/bin/sh
+
+key_path=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -f)
+      shift
+      key_path="$1"
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$key_path" ]; then
+  exit 2
+fi
+
+mkdir -p "$(dirname "$key_path")"
+touch "$key_path" "$key_path.pub"
+SSH_KEYGEN
+
+  cat > "$fake_bin/ssh-agent" <<'SSH_AGENT'
+#!/bin/sh
+printf '%s\n' 'SSH_AUTH_SOCK=/tmp/macsetup-test-agent.sock; export SSH_AUTH_SOCK;'
+printf '%s\n' 'SSH_AGENT_PID=12345; export SSH_AGENT_PID;'
+printf '%s\n' 'echo Agent pid 12345;'
+SSH_AGENT
+
+  chmod +x "$fake_bin/uname" "$fake_bin/git" "$fake_bin/ssh-keygen" "$fake_bin/ssh-agent"
+}
+
+runGitSetupWithPlatform() {
+  local uname_value="$1"
+  local home_dir="$tmp_root/home-$uname_value"
+  local fake_bin="$tmp_root/bin-$uname_value"
+  local output_file="$tmp_root/output-$uname_value"
+
+  mkdir -p "$home_dir"
+  writeFakeCommands "$fake_bin" "$uname_value"
+
+  {
+    printf 'y\n'
+    printf 'Test User\n'
+    printf 'test@example.com\n'
+    printf 'y\n'
+    printf '\n'
+    printf '\n'
+  } | HOME="$home_dir" PATH="$fake_bin:$PATH" MACSETUP_UI=plain TERM="$TERM" bash -c '
+    source ./lib/macsetup/constants.sh
+    source ./lib/macsetup/helperFunctions.sh
+    source ./sections/setup_git.sh
+    runSection
+  ' > "$output_file"
+
+  printf '%s\n' "$home_dir"
+}
+
+echo "Checking Git SSH config on Linux-compatible platforms..."
+linux_home="$(runGitSetupWithPlatform Linux)"
+linux_ssh_config="$linux_home/.ssh/config"
+test -f "$linux_ssh_config"
+grep -q "AddKeysToAgent yes" "$linux_ssh_config"
+grep -q "IdentityFile $linux_home/.ssh/git_key_ecdsa" "$linux_ssh_config"
+! grep -q "UseKeychain yes" "$linux_ssh_config"
+
+echo "Checking Git SSH config on macOS..."
+darwin_home="$(runGitSetupWithPlatform Darwin)"
+darwin_ssh_config="$darwin_home/.ssh/config"
+test -f "$darwin_ssh_config"
+grep -q "AddKeysToAgent yes" "$darwin_ssh_config"
+grep -q "UseKeychain yes" "$darwin_ssh_config"
+grep -q "IdentityFile $darwin_home/.ssh/git_key_ecdsa" "$darwin_ssh_config"

--- a/ci/test_terminal_compat.sh
+++ b/ci/test_terminal_compat.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$repo_root"
+
+runWithoutStderr() {
+  local stderr_file=""
+
+  stderr_file="$(mktemp)"
+  if ! "$@" 2>"$stderr_file"; then
+    sed -n '1,120p' "$stderr_file" >&2
+    rm -f "$stderr_file"
+    return 1
+  fi
+
+  if [ -s "$stderr_file" ]; then
+    sed -n '1,120p' "$stderr_file" >&2
+    rm -f "$stderr_file"
+    return 1
+  fi
+
+  rm -f "$stderr_file"
+}
+
+echo "Checking constants with unknown Ghostty TERM..."
+runWithoutStderr env TERM=xterm-ghostty bash -c '
+  source ./lib/macsetup/constants.sh
+  test -n "$RED"
+  test -n "$RESET_COLOR"
+'
+
+echo "Checking constants with dumb TERM..."
+runWithoutStderr env TERM=dumb bash -c '
+  source ./lib/macsetup/constants.sh
+  test -z "$RED"
+  test -z "$RESET_COLOR"
+'
+
+echo "Checking splash screens with unknown Ghostty TERM..."
+runWithoutStderr env TERM=xterm-ghostty bash -c '
+  source ./config/dotfiles/mac/config_vars.sh
+  source ./config/dotfiles/mac/utility_aliases.sh
+  source ./config/dotfiles/mac/splash_screens.sh
+  wolf >/dev/null
+  charizard >/dev/null
+'
+
+echo "Checking splash clear fallback with unknown Ghostty TERM..."
+runWithoutStderr env TERM=xterm-ghostty bash -c '
+  tmp_home="$(mktemp -d)"
+  cleanup() {
+    rm -rf "$tmp_home"
+  }
+  trap cleanup EXIT
+  cp ./config/dotfiles/mac/config_vars.sh "$tmp_home/.config_vars"
+  cp ./config/dotfiles/mac/utility_aliases.sh "$tmp_home/.utility_aliases"
+  cp ./config/dotfiles/mac/splash_screens.sh "$tmp_home/.splash_screens"
+  HOME="$tmp_home"
+  source ./config/dotfiles/mac/bashrc.sh || true
+  declare -F clearTerminal >/dev/null
+  clearTerminal >/dev/null
+'

--- a/config/dotfiles/mac/bashrc.sh
+++ b/config/dotfiles/mac/bashrc.sh
@@ -4,14 +4,24 @@ source ~/.splash_screens
 
 # This file is processed on each interactive invocation of bash
 
+clearTerminal() {
+  if command -v clear >/dev/null 2>&1 && clear 2>/dev/null; then
+    return 0
+  fi
+
+  if [ -n "${TERM:-}" ] && [ "$TERM" != "dumb" ]; then
+    printf '\033[H\033[2J'
+  fi
+}
+
+# Avoid problems with scp -- don't process the rest of the file if non-interactive
+[[ $- != *i* ]] && return
+
 # Custom binding Overrides to use Ctrl+WASD to move around the terminal line
 bind '"\C-a": backward-word'
 bind '"\C-d": forward-word' # Note Ctrl+D is EOF, so this is a bit of a misnomer to override
 bind '"\C-s": beginning-of-line'
 bind '"\C-w": end-of-line'
-
-# Avoid problems with scp -- don't process the rest of the file if non-interactive
-[[ $- != *i* ]] && return
 
 if [[ -n $SSH_CONNECTION ]]; then
   export EDITOR='vim'
@@ -111,7 +121,7 @@ if [[ $(echo $BASH_VERSION) ]]; then
 fi
 
 splash_screen() {
-  clear
+  clearTerminal
   local SPLASH_COMMAND=
   if type $SPLASH_COMMAND >/dev/null; then
     $SPLASH_COMMAND

--- a/config/dotfiles/mac/splash_screens.sh
+++ b/config/dotfiles/mac/splash_screens.sh
@@ -1,3 +1,17 @@
+terminalColumns() {
+  local columns=""
+
+  if command -v tput >/dev/null 2>&1; then
+    columns="$(tput cols 2>/dev/null || true)"
+  fi
+
+  if [ -n "$columns" ]; then
+    printf '%s\n' "$columns"
+  else
+    printf '%s\n' "${COLUMNS:-80}"
+  fi
+}
+
 wolf() {
   IFS='' read -r -d '' WOLF <<'EOF'
                                __
@@ -29,12 +43,14 @@ wolf() {
 EOF
   rainbowtext "$WOLF" -S 35
   # Print a horizontal divider
-  COLUMNS=$(tput cols)
-  HORIZONTAL_ROW=$(printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' ─)
-  if [ $COLUMNS -gt 200 ]; then
-    rainbowtext $HORIZONTAL_ROW -S 48 -p 10.0
+  local columns
+  local horizontal_row
+  columns="$(terminalColumns)"
+  horizontal_row="$(printf '%*s\n' "$columns" '' | tr ' ' ─)"
+  if [ "$columns" -gt 200 ]; then
+    rainbowtext "$horizontal_row" -S 48 -p 10.0
   else
-    rainbowtext $HORIZONTAL_ROW -S 48 -p 7.0
+    rainbowtext "$horizontal_row" -S 48 -p 7.0
   fi
 }
 
@@ -111,11 +127,13 @@ charizard() {
 EOF
   rainbowtext "$CHARIZARD" -S 35
   # Print a horizontal divider
-  COLUMNS=$(tput cols)
-  HORIZONTAL_ROW=$(printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' ─)
-  if [ $COLUMNS -gt 200 ]; then
-    rainbowtext $HORIZONTAL_ROW -S 48 -p 10.0
+  local columns
+  local horizontal_row
+  columns="$(terminalColumns)"
+  horizontal_row="$(printf '%*s\n' "$columns" '' | tr ' ' ─)"
+  if [ "$columns" -gt 200 ]; then
+    rainbowtext "$horizontal_row" -S 48 -p 10.0
   else
-    rainbowtext $HORIZONTAL_ROW -S 48 -p 7.0
+    rainbowtext "$horizontal_row" -S 48 -p 7.0
   fi
 }

--- a/lib/macsetup/appConfigUtil.sh
+++ b/lib/macsetup/appConfigUtil.sh
@@ -10,8 +10,8 @@ configureICU4C() {
   # Add To Path
   addLineToFiles "" ~/.bash_profile ~/.zprofile
   addLineToFiles "# Add icu4c to path" ~/.bash_profile ~/.zprofile
-  addLineToFiles "export PATH=\"$ICU_PATH/bin:\$PATH\"" ~/.bash_profile ~/.zprofile
-  addLineToFiles "export PATH=\"$ICU_PATH/sbin:\$PATH\"" ~/.bash_profile ~/.zprofile
+  addLineToFiles "$(pathPrependShellLine "$ICU_PATH/bin")" ~/.bash_profile ~/.zprofile
+  addLineToFiles "$(pathPrependShellLine "$ICU_PATH/sbin")" ~/.bash_profile ~/.zprofile
   # Enable Compilers to find icu4c
   addLineToFiles "" ~/.bash_profile ~/.zprofile
   addLineToFiles "# Enable compilers to find icu4c" ~/.bash_profile ~/.zprofile
@@ -33,8 +33,8 @@ configureOpenSSL() {
   # Add To Path
   addLineToFiles "" ~/.bash_profile ~/.zprofile
   addLineToFiles "# Add openssl to path" ~/.bash_profile ~/.zprofile
-  addLineToFiles "export PATH=\"$OPEN_SSL_PATH/bin:\$PATH\"" ~/.bash_profile ~/.zprofile
-  addLineToFiles "export PATH=\"$OPEN_SSL_PATH/sbin:\$PATH\"" ~/.bash_profile ~/.zprofile
+  addLineToFiles "$(pathPrependShellLine "$OPEN_SSL_PATH/bin")" ~/.bash_profile ~/.zprofile
+  addLineToFiles "$(pathPrependShellLine "$OPEN_SSL_PATH/sbin")" ~/.bash_profile ~/.zprofile
 
   # TODO: Need to make sure that this adds values to these env vars rather than directly
   # setting them
@@ -114,7 +114,7 @@ configureVSCode() {
       info 'Adding VSCode to $PATH'
       addLineToFiles "" ~/.bash_profile ~/.zprofile
       addLineToFiles "# Add Visual Studio Code (code)" ~/.bash_profile ~/.zprofile
-      addLineToFiles 'export PATH="$PATH:/Applications/Visual Studio Code.app/Contents/Resources/app/bin"' ~/.bash_profile ~/.zprofile
+      addLineToFiles "$(pathAppendShellLine '/Applications/Visual Studio Code.app/Contents/Resources/app/bin')" ~/.bash_profile ~/.zprofile
 
       info 'Setting settings.json file'
       SETTINGS_PATH=~/Library/'Application Support'/Code/User/settings.json

--- a/lib/macsetup/constants.sh
+++ b/lib/macsetup/constants.sh
@@ -4,18 +4,40 @@
 # Constants For Install Script #
 ################################
 
+macsetupAnsiCode() {
+  if [ -n "${TERM:-}" ] && [ "${TERM:-}" != "dumb" ]; then
+    printf '\033[%sm' "$1"
+  fi
+}
+
+macsetupTerminalCode() {
+  local ansi_code="$1"
+  shift
+
+  local tput_code=""
+  if [ -n "${TERM:-}" ] && [ "${TERM:-}" != "dumb" ] && command -v tput >/dev/null 2>&1; then
+    tput_code="$(tput "$@" 2>/dev/null || true)"
+  fi
+
+  if [ -n "$tput_code" ]; then
+    printf '%s' "$tput_code"
+  else
+    macsetupAnsiCode "$ansi_code"
+  fi
+}
+
 # FONT COLORS
-RED=$(tput setaf 9)
-ORANGE=$(tput setaf 172)
-GREEN=$(tput setaf 2)
-BLUE=$(tput setaf 12)
-YELLOW=$(tput setaf 11)
-GRAY=$(tput setaf 8)
-LIGHT_GRAY=$(tput setaf 7)
-HEADER_BLUE=$'\033[38;2;194;203;237m'
-BOLD=$(tput bold)
-DIM=$(tput dim)
-RESET_COLOR=$(tput sgr0)
+RED="$(macsetupTerminalCode "91" setaf 9)"
+ORANGE="$(macsetupTerminalCode "38;5;172" setaf 172)"
+GREEN="$(macsetupTerminalCode "32" setaf 2)"
+BLUE="$(macsetupTerminalCode "94" setaf 12)"
+YELLOW="$(macsetupTerminalCode "93" setaf 11)"
+GRAY="$(macsetupTerminalCode "90" setaf 8)"
+LIGHT_GRAY="$(macsetupTerminalCode "37" setaf 7)"
+HEADER_BLUE="$(macsetupAnsiCode "38;2;194;203;237")"
+BOLD="$(macsetupTerminalCode "1" bold)"
+DIM="$(macsetupTerminalCode "2" dim)"
+RESET_COLOR="$(macsetupTerminalCode "0" sgr0)"
 
 UI_BOX_COLOR="${DIM}${LIGHT_GRAY}"
 UI_TITLE_COLOR="${BOLD}${HEADER_BLUE}"

--- a/lib/macsetup/platform.sh
+++ b/lib/macsetup/platform.sh
@@ -16,6 +16,70 @@ cmdExists() {
   [ "$#" -gt 0 ] && hash "$1" 2>/dev/null
 }
 
+pathContainsEntry() {
+  local path_entry="$1"
+  local old_ifs="$IFS"
+  local part=""
+
+  IFS=:
+  for part in $PATH; do
+    if [ "$part" = "$path_entry" ]; then
+      IFS="$old_ifs"
+      return 0
+    fi
+  done
+  IFS="$old_ifs"
+
+  return 1
+}
+
+prependPathEntry() {
+  local path_entry="$1"
+
+  if [ -z "$path_entry" ]; then
+    return 0
+  fi
+
+  if ! pathContainsEntry "$path_entry"; then
+    PATH="$path_entry${PATH:+:$PATH}"
+    export PATH
+  fi
+}
+
+prependPathEntries() {
+  local path_entries=("$@")
+  local index=""
+
+  for (( index=${#path_entries[@]} - 1; index >= 0; index-- )); do
+    prependPathEntry "${path_entries[$index]}"
+  done
+}
+
+appendPathEntry() {
+  local path_entry="$1"
+
+  if [ -z "$path_entry" ]; then
+    return 0
+  fi
+
+  if ! pathContainsEntry "$path_entry"; then
+    PATH="${PATH:+$PATH:}$path_entry"
+    export PATH
+  fi
+}
+
+pathPrependShellLine() {
+  local path_entry="$1"
+
+  printf 'case ":$PATH:" in *":%s:"*) ;; *) export PATH="%s:$PATH" ;; esac\n' "$path_entry" "$path_entry"
+}
+
+pathAppendShellLine() {
+  local path_entry="$1"
+
+  printf 'case ":$PATH:" in *":%s:"*) ;; *) export PATH="$PATH:%s" ;; esac\n' "$path_entry" "$path_entry"
+}
+
 currShell() {
   local curr_shell=""
 

--- a/sections/install_node.sh
+++ b/sections/install_node.sh
@@ -8,7 +8,7 @@ function runSection {
       assertFileExists ~/.tool-versions "Found ~/.tool-versions file" "~/.tool-versions not found, cannot install Node via \`asdf\`."
 
       info "Adding Node Plugin..."
-      asdf plugin-add nodejs
+      asdf plugin add nodejs
 
       if [[ $REPLY =~ ^[Yy]$ ]]; then
         info "Installing Node from ~/.tool-versions: "$'\n'"---TOOLS---"$'\n'"$(cat ~/.tool-versions)"$'\n'"-----------"

--- a/sections/install_postgres.sh
+++ b/sections/install_postgres.sh
@@ -8,7 +8,7 @@ function runSection {
       assertFileExists ~/.tool-versions "Found ~/.tool-versions file" "~/.tool-versions not found, cannot install Postgres via \`asdf\`."
 
       info "Adding Postgres Plugin..."
-      asdf plugin-add postgres
+      asdf plugin add postgres
 
       if [[ $REPLY =~ ^[Yy]$ ]]; then
         info "Installing Postgres from ~/.tool-versions: "$'\n'"---TOOLS---"$'\n'"$(cat ~/.tool-versions)"$'\n'"-----------"

--- a/sections/install_python.sh
+++ b/sections/install_python.sh
@@ -8,7 +8,7 @@ function runSection {
       assertFileExists ~/.tool-versions "Found ~/.tool-versions file" "~/.tool-versions not found, cannot install Python via \`asdf\`."
 
       info "Adding Python Plugin..."
-      asdf plugin-add python
+      asdf plugin add python
 
       if [[ $REPLY =~ ^[Yy]$ ]]; then
         info "Installing Python from ~/.tool-versions: "$'\n'"---TOOLS---"$'\n'"$(cat ~/.tool-versions)"$'\n'"-----------"

--- a/sections/install_ruby.sh
+++ b/sections/install_ruby.sh
@@ -8,7 +8,7 @@ function runSection {
       assertFileExists ~/.tool-versions "Found ~/.tool-versions file" "~/.tool-versions not found, cannot install Ruby via \`asdf\`."
 
       info "Adding Ruby Plugin..."
-      asdf plugin-add ruby https://github.com/asdf-vm/asdf-ruby.git
+      asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git
 
       if [[ $REPLY =~ ^[Yy]$ ]]; then
         info "Installing Ruby from ~/.tool-versions: "$'\n'"---TOOLS---"$'\n'"$(cat ~/.tool-versions)"$'\n'"-----------"

--- a/sections/setup_asdf.sh
+++ b/sections/setup_asdf.sh
@@ -4,34 +4,240 @@
 function runSection {
   promptNewSection "ASDF Version Manager"
   if [[ $REPLY =~ ^[Yy]$ ]]; then
-    local currDir="$(scriptDirectory)";
-    git clone https://github.com/asdf-vm/asdf.git ~/.asdf
-    cd ~/.asdf
-    git checkout "$(git describe --abbrev=0 --tags)"
-
-    source $HOME/.asdf/asdf.sh
-    assertPackageInstallation asdf "asdf"
-    cd "$currDir"
-
-    info "Configuring asdf version manager in .bash_profile and .zprofile"
-    addLineToFiles "" ~/.bash_profile ~/.zprofile
-    addLineToFiles "# asdf version manager" ~/.bash_profile ~/.zprofile
-    addLineToFiles '. $HOME/.asdf/asdf.sh' ~/.bash_profile ~/.zprofile
-    addLineToFiles '. $HOME/.asdf/completions/asdf.bash' ~/.bash_profile # This line does not apply to .zprofile
-    success 'Added asdf configuration to ~/.bash_profile and ~/.zprofile'
-
-    source ~/.bash_profile
-    source ~/.zprofile
-
-    info "Backing up ~/.tool-versions"
-    backupFile ~/.tool-versions tool-versions
-
-    cp "$MACSETUP_CONFIG_DIR"/asdf/tool-versions ~/.tool-versions
-    assertFileExists ~/.tool-versions "~/.tool-versions set" "Failed to set ~/.tool-versions"
-
-    assertPackageInstallation asdf "asdf"
+    setupAsdf
   else
     # Skip this installation section
     info "Skipping..."
   fi
+}
+
+function setupAsdf {
+  local asdfVersion="${ASDF_VERSION:-v0.19.0}"
+  local asdfDataDir="${ASDF_DATA_DIR:-$HOME/.asdf}"
+  local asdfBinDir="$asdfDataDir/bin"
+  local asdfBinary="$asdfBinDir/asdf"
+
+  export ASDF_DATA_DIR="$asdfDataDir"
+
+  if ! mkdir -p "$asdfBinDir" "$asdfDataDir/shims"; then
+    fail "Failed to create asdf directories under $asdfDataDir"
+    return 1
+  fi
+
+  if ! installAsdfBinary "$asdfVersion" "$asdfBinary"; then
+    return 1
+  fi
+
+  prependPathEntries "$asdfDataDir/shims" "$asdfBinDir"
+  hash -r 2>/dev/null || true
+  assertPackageInstallation asdf "asdf"
+  if ! cmdExists asdf; then
+    return 1
+  fi
+  if ! assertAsdfVersion "$asdfVersion"; then
+    return 1
+  fi
+
+  if ! configureAsdfShell "$asdfDataDir"; then
+    return 1
+  fi
+
+  info "Backing up ~/.tool-versions"
+  backupFile ~/.tool-versions tool-versions
+
+  if ! cp "$MACSETUP_CONFIG_DIR"/asdf/tool-versions ~/.tool-versions; then
+    fail "Failed to copy asdf tool versions"
+    return 1
+  fi
+  assertFileExists ~/.tool-versions "~/.tool-versions set" "Failed to set ~/.tool-versions"
+
+  assertPackageInstallation asdf "asdf"
+}
+
+function installAsdfBinary {
+  local asdfVersion="$1"
+  local asdfBinary="$2"
+  local installedVersion=""
+  local platform=""
+  local arch=""
+  local archiveName=""
+  local archiveUrl=""
+  local tmpDir=""
+  local archivePath=""
+
+  if [ -x "$asdfBinary" ]; then
+    installedVersion="$("$asdfBinary" --version 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^v?[0-9]+\.[0-9]+\.[0-9]+$/) { print $i; exit } }')"
+    if [ "$installedVersion" = "$asdfVersion" ] || [ "$installedVersion" = "${asdfVersion#v}" ]; then
+      info "asdf $asdfVersion is already installed at $asdfBinary"
+      return 0
+    fi
+  fi
+
+  platform="$(asdfReleasePlatform)" || return 1
+  arch="$(asdfReleaseArch)" || return 1
+  archiveName="asdf-${asdfVersion}-${platform}-${arch}.tar.gz"
+  archiveUrl="https://github.com/asdf-vm/asdf/releases/download/${asdfVersion}/${archiveName}"
+  tmpDir="$(mktemp -d 2>/dev/null || mktemp -d -t macsetup-asdf)"
+  if [ -z "$tmpDir" ]; then
+    fail "Failed to create temporary directory for asdf download"
+    return 1
+  fi
+  archivePath="$tmpDir/$archiveName"
+
+  info "Downloading asdf $asdfVersion for $platform/$arch"
+  if cmdExists curl; then
+    if ! curl -fsSL "$archiveUrl" -o "$archivePath"; then
+      fail "Failed to download asdf from $archiveUrl"
+      rm -rf "$tmpDir"
+      return 1
+    fi
+  elif cmdExists wget; then
+    if ! wget -qO "$archivePath" "$archiveUrl"; then
+      fail "Failed to download asdf from $archiveUrl"
+      rm -rf "$tmpDir"
+      return 1
+    fi
+  else
+    fail "Failed to download asdf: curl or wget is required"
+    rm -rf "$tmpDir"
+    return 1
+  fi
+
+  if ! tar -xzf "$archivePath" -C "$tmpDir"; then
+    fail "Failed to extract $archiveName"
+    rm -rf "$tmpDir"
+    return 1
+  fi
+
+  if [ ! -f "$tmpDir/asdf" ]; then
+    fail "Failed to find asdf binary in $archiveName"
+    rm -rf "$tmpDir"
+    return 1
+  fi
+
+  if ! cp "$tmpDir/asdf" "$asdfBinary"; then
+    fail "Failed to install asdf binary to $asdfBinary"
+    rm -rf "$tmpDir"
+    return 1
+  fi
+
+  if ! chmod +x "$asdfBinary"; then
+    fail "Failed to make asdf binary executable at $asdfBinary"
+    rm -rf "$tmpDir"
+    return 1
+  fi
+  rm -rf "$tmpDir"
+  success "Installed asdf $asdfVersion to $asdfBinary"
+}
+
+function assertAsdfVersion {
+  local expectedVersion="$1"
+  local activeVersion=""
+
+  activeVersion="$(asdf --version 2>/dev/null)"
+  if echo "$activeVersion" | grep -Fq "${expectedVersion#v}"; then
+    success "Using asdf $expectedVersion"
+    return 0
+  fi
+
+  fail "Expected asdf $expectedVersion, but found: $activeVersion"
+  return 1
+}
+
+function asdfReleasePlatform {
+  case "$(uname -s)" in
+    Darwin)
+      echo "darwin"
+      ;;
+    Linux)
+      echo "linux"
+      ;;
+    *)
+      fail "Unsupported asdf platform: $(uname -s)"
+      return 1
+      ;;
+  esac
+}
+
+function asdfReleaseArch {
+  case "$(uname -m)" in
+    arm64 | aarch64)
+      echo "arm64"
+      ;;
+    x86_64 | amd64)
+      echo "amd64"
+      ;;
+    i386 | i686)
+      echo "386"
+      ;;
+    *)
+      fail "Unsupported asdf architecture: $(uname -m)"
+      return 1
+      ;;
+  esac
+}
+
+function configureAsdfShell {
+  local asdfDataDir="$1"
+  local files=(~/.bash_profile ~/.bashrc ~/.zprofile ~/.zshrc)
+
+  info "Configuring asdf version manager in shell startup files"
+  removeLegacyAsdfShellConfig "${files[@]}" || return 1
+  addAsdfLineToFiles "" "${files[@]}"
+  addAsdfLineToFiles "# asdf version manager" "${files[@]}"
+  addAsdfLineToFiles "export ASDF_DATA_DIR=\"$asdfDataDir\"" "${files[@]}"
+  addAsdfLineToFiles "$(pathPrependShellLine '$ASDF_DATA_DIR/bin')" "${files[@]}"
+  addAsdfLineToFiles "$(pathPrependShellLine '$ASDF_DATA_DIR/shims')" "${files[@]}"
+  success "Added asdf configuration to shell startup files"
+}
+
+function addAsdfLineToFiles {
+  local text="$1"
+  local files=("${@:2}")
+  local file=""
+  local line="$text"
+
+  if [[ $text =~ ^\# ]]; then
+    line="$text (Added by MacSetup)"
+  fi
+
+  for file in "${files[@]}"; do
+    touch "$file"
+    if ! grep -Fqx "$line" "$file"; then
+      echo "$line" >> "$file"
+    fi
+  done
+}
+
+function removeLegacyAsdfShellConfig {
+  local files=("$@")
+  local file=""
+  local tmpFile=""
+
+  for file in "${files[@]}"; do
+    if [ ! -f "$file" ]; then
+      continue
+    fi
+
+    if grep -Fqx \
+      -e '. $HOME/.asdf/asdf.sh' \
+      -e '. $HOME/.asdf/completions/asdf.bash' \
+      -e 'export PATH="$ASDF_DATA_DIR/bin:$ASDF_DATA_DIR/shims:$PATH"' \
+      "$file"; then
+      backupFile "$file" "$(basename "$file")"
+      tmpFile="$(mktemp)"
+      grep -Fvx \
+        -e '. $HOME/.asdf/asdf.sh' \
+        -e '. $HOME/.asdf/completions/asdf.bash' \
+        -e 'export PATH="$ASDF_DATA_DIR/bin:$ASDF_DATA_DIR/shims:$PATH"' \
+        "$file" > "$tmpFile" || true
+      if ! cp "$tmpFile" "$file"; then
+        fail "Failed to remove legacy asdf shell config from $file"
+        rm -f "$tmpFile"
+        return 1
+      fi
+      rm -f "$tmpFile"
+      info "Removed legacy asdf shell config from $file"
+    fi
+  done
 }

--- a/sections/setup_git.sh
+++ b/sections/setup_git.sh
@@ -67,7 +67,9 @@ function runSection {
         addLineToFiles "# Git SSH" $SSH_CONFIG
         addLineToFiles "Host *" $SSH_CONFIG
         addLineToFiles "  AddKeysToAgent yes" $SSH_CONFIG
-        addLineToFiles "  UseKeychain yes" $SSH_CONFIG
+        if isMacOs; then
+          addLineToFiles "  UseKeychain yes" $SSH_CONFIG
+        fi
         addLineToFiles "  IdentityFile $KEY_PATH" $SSH_CONFIG
         # Reset the Internal Field Separator
         unset IFS


### PR DESCRIPTION
## Summary
- install asdf v0.19.0 using the current precompiled binary release shape instead of the legacy asdf.sh git checkout
- add shared idempotent PATH helpers for runtime PATH updates and generated shell startup lines
- configure ASDF_DATA_DIR plus guarded asdf binary and shims path prepends in shell startup files, while removing old MacSetup asdf.sh source lines and the prior unguarded PATH line
- move installer-generated PATH config for icu4c, openssl, VSCode, and asdf onto the shared helper pattern
- tolerate unknown terminal types such as xterm-ghostty by suppressing unsafe tput calls and using ANSI fallbacks where appropriate
- update Ruby, Node, Python, and Postgres sections from the removed asdf plugin-add command to asdf plugin add
- keep the asdf setup idempotent by reusing an existing matching binary and avoiding duplicate shell config lines
- audit section OS behavior and keep the macOS-only SSH UseKeychain option out of Linux-compatible Git setup

## Validation
- bash -n sections/setup_asdf.sh sections/install_ruby.sh sections/install_node.sh sections/install_python.sh sections/install_postgres.sh sections/setup_git.sh ci/test_setup_git_platform.sh ci/checks.sh
- git diff --check
- bash ./ci/test_path_helpers.sh
- bash ./ci/test_terminal_compat.sh
- bash ./ci/test_setup_git_platform.sh
- bash ./ci/checks.sh
- skipped install with TERM=xterm-ghostty and empty stderr
- Docker focused asdf install: selected only ASDF in macsetup:asdf-latest, verified asdf version v0.19.0, and verified legacy asdf.sh lines are removed
- Docker idempotence check: ran the ASDF section twice in one container, verified the second run reused the installed binary
- Docker zsh startup check: sourced both .zprofile and .zshrc, verified ASDF bin and shims each appear exactly once in PATH
- Docker migration check: seeded the previous unguarded ASDF PATH line in .zprofile and .zshrc, verified it is removed and guarded config does not duplicate PATH
- start.sh Docker sandbox path: hard-coded Sandbox (Docker) -> Modern Vim + Coc and selected only ASDF; install finished with no failures

## Review Feedback
- Addressed Codex review feedback by replacing duplicated ASDF PATH exports with guarded PATH prepends that are safe when both .zprofile and .zshrc are sourced.
- Follow-up: added shared PATH helper utilities so future installer code uses one idempotent PATH pattern.