### PR TITLE
Fix clear fallback for unknown Ghostty terminfo

### DIFF
--- a/ci/test_terminal_compat.sh
+++ b/ci/test_terminal_compat.sh
@@ -61,4 +61,6 @@ runWithoutStderr env TERM=xterm-ghostty bash -c '
   source ./config/dotfiles/mac/bashrc.sh || true
   declare -F clearTerminal >/dev/null
   clearTerminal >/dev/null
+  declare -F clear >/dev/null
+  clear >/dev/null
 '

--- a/config/dotfiles/mac/bashrc.sh
+++ b/config/dotfiles/mac/bashrc.sh
@@ -5,13 +5,17 @@ source ~/.splash_screens
 # This file is processed on each interactive invocation of bash
 
 clearTerminal() {
-  if command -v clear >/dev/null 2>&1 && clear 2>/dev/null; then
+  if command -v clear >/dev/null 2>&1 && command clear 2>/dev/null; then
     return 0
   fi
 
   if [ -n "${TERM:-}" ] && [ "$TERM" != "dumb" ]; then
     printf '\033[H\033[2J'
   fi
+}
+
+clear() {
+  clearTerminal
 }
 
 # Avoid problems with scp -- don't process the rest of the file if non-interactive


### PR DESCRIPTION
## Summary
- wrap the managed `clear` command so interactive shells use the existing ANSI fallback when terminfo does not know `xterm-ghostty`
- make `clearTerminal` call the real binary via `command clear` to avoid recursion through the wrapper
- extend terminal compatibility coverage to assert typed `clear` is available and quiet

## Validation
- `bash -n config/dotfiles/mac/bashrc.sh ci/test_terminal_compat.sh`
- `bash ./ci/test_terminal_compat.sh`
- `bash ./ci/checks.sh`
- `git diff --check`