### PR TITLE
Add top-level test runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run shell and helper checks
-        run: bash ./ci/checks.sh
+        run: bash ./test.sh checks
 
   docker_old_profile:
     name: Docker sandbox smoke - old Vim profile
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build and run old Vim sandbox
-        run: bash ./ci/docker_install_smoke.sh vim-old ubuntu:18.04
+        run: bash ./test.sh docker-old
 
   start_sandbox:
     name: start.sh Docker sandbox smoke - modern profile
@@ -38,11 +38,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run start.sh through Docker sandbox
-        run: |
-          {
-            printf '1\n'
-            printf '2\n'
-            for _ in {1..32}; do
-              printf 'n\n'
-            done
-          } | ./start.sh
+        run: bash ./test.sh start-sandbox

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ installer remains scriptable and portable.
 - `config/` contains desired machine configuration such as dotfiles, Git config, VSCode settings, terminal preferences, app preferences, and asdf tool versions.
 - `assets/` contains copied/static payloads such as fonts, wallpapers, Vim runtime files, the Aerial screensaver, splash images, and demo media.
 
+## Testing
+
+Run the local shell and installer checks with:
+
+```bash
+$ ./test.sh
+```
+
+Docker-backed smoke checks are also available through `./test.sh docker`.
+
 ## Demo
 
 ![Demo](./assets/public/demo.gif)

--- a/ci/checks.sh
+++ b/ci/checks.sh
@@ -12,7 +12,7 @@ no_prompts() {
 }
 
 echo "Checking shell syntax..."
-find start.sh install.sh clean.sh diff.sh sections lib config assets ci -name '*.sh' -type f -print0 \
+find start.sh install.sh clean.sh diff.sh test.sh sections lib config assets ci -name '*.sh' -type f -print0 \
   | xargs -0 bash -n
 
 echo "Checking start.sh quit path..."

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$repo_root"
+
+usage() {
+  cat <<'USAGE'
+Usage: ./test.sh [checks|docker-old|start-sandbox|docker|all]
+
+Modes:
+  checks         Run shell syntax, helper, and isolated installer checks.
+  docker-old     Run the old Vim Docker sandbox smoke check.
+  start-sandbox  Run start.sh through the modern Docker sandbox path.
+  docker         Run all Docker-backed smoke checks.
+  all            Run checks and Docker-backed smoke checks.
+
+Default mode: checks
+USAGE
+}
+
+noPrompts() {
+  for _ in {1..32}; do
+    printf 'n\n'
+  done
+}
+
+runChecks() {
+  bash ./ci/checks.sh
+}
+
+runDockerOldProfile() {
+  bash ./ci/docker_install_smoke.sh vim-old ubuntu:18.04
+}
+
+runStartSandbox() {
+  {
+    printf '1\n'
+    printf '2\n'
+    noPrompts
+  } | ./start.sh
+}
+
+mode="${1:-checks}"
+
+case "$mode" in
+  checks)
+    runChecks
+    ;;
+  docker-old)
+    runDockerOldProfile
+    ;;
+  start-sandbox)
+    runStartSandbox
+    ;;
+  docker)
+    runDockerOldProfile
+    runStartSandbox
+    ;;
+  all)
+    runChecks
+    runDockerOldProfile
+    runStartSandbox
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary
- add `./test.sh` as the repo-level test entrypoint
- expose modes for local checks, Docker old Vim smoke, start.sh sandbox smoke, combined Docker smoke, and all checks
- route GitHub Actions through `./test.sh` so CI and local testing use the same commands
- document the local test command in the README

## Validation
- `bash -n test.sh ci/checks.sh .github/workflows/ci.yml`
- `./test.sh --help`
- `./test.sh checks`
- `git diff --check`